### PR TITLE
More direct wording on the 'mailinglist' page

### DIFF
--- a/content/mailinglist.md
+++ b/content/mailinglist.md
@@ -6,5 +6,4 @@ description:
 To privately disclose a security vulnerability in one
 of our projects, use [this process](https://www.apache.org/security/).
 
-If you'd like to discuss ASF-wide security-related topics, you might
-be interested in joining the public `security-discuss` mailinglist: read the [archives](https://lists.apache.org/list.html?security-discuss@community.apache.org) and subscribe by sending an email to [security-discuss-subscribe@community.apache.org](mailto:security-discuss-subscribe@community.apache.org). Once subscribed, you can send your mail to [security-discuss@community.apache.org](security-discuss@community.apache.org)
+To discuss ASF-wide security-related topics, join the public `security-discuss` mailinglist: read the [archives](https://lists.apache.org/list.html?security-discuss@community.apache.org) and subscribe by emailing [security-discuss-subscribe@community.apache.org](mailto:security-discuss-subscribe@community.apache.org). Once subscribed, you can send your mail to [security-discuss@community.apache.org](security-discuss@community.apache.org)


### PR DESCRIPTION
Shorter is nicer - but the real reason for this PR is to test the Jenkins deployment pipeline on merge :)