### PR TITLE
'lighten' Attic description

### DIFF
--- a/content/blog/data-processing-compliance-statements-and-sla.md
+++ b/content/blog/data-processing-compliance-statements-and-sla.md
@@ -65,4 +65,4 @@ comes mainly from the transparency that we practice in all aspects of developmen
 
 # Attic
 
-The Attic contains historic code that is no longer fit for purpose. It is code that can no longer be used as it was originally intended. A project that was moved to the [Attic](https://attic.apache.org) is not subject to our various security- and release-policies. It is no longer considered a release by the Apache Software Foundation.
+The [Attic](https://attic.apache.org) contains historic code that is no longer maintained. We make no guarantees on whether it can still be used as it was originally intended. A project that was moved to the [Attic](https://attic.apache.org) is not subject to our various security- and release-policies. It is no longer considered a release by the Apache Software Foundation.

--- a/content/blog/data-processing-compliance-statements-and-sla.md
+++ b/content/blog/data-processing-compliance-statements-and-sla.md
@@ -67,5 +67,5 @@ comes mainly from the transparency that we practice in all aspects of developmen
 
 The [Attic](https://attic.apache.org) contains historic code that is no longer maintained.
 We make no guarantees as to whether it can still be used as it was originally intended.
-A project in the [Attic](https://attic.apache.org) is not subject to our various security- and release-policies.
-It is no longer considered a release by the Apache Software Foundation, is not subject to any oversight, and may no longer be fit for purpose.
+A project in the [Attic](https://attic.apache.org) is not subject to our various security- and release policies.
+It is not subject to any oversight, its releases are no longer considered releases by the Apache Software Foundation, and they may no longer be fit for purpose.

--- a/content/blog/data-processing-compliance-statements-and-sla.md
+++ b/content/blog/data-processing-compliance-statements-and-sla.md
@@ -65,4 +65,7 @@ comes mainly from the transparency that we practice in all aspects of developmen
 
 # Attic
 
-The [Attic](https://attic.apache.org) contains historic code that is no longer maintained. We make no guarantees on whether it can still be used as it was originally intended. A project that was moved to the [Attic](https://attic.apache.org) is not subject to our various security- and release-policies. It is no longer considered a release by the Apache Software Foundation, is not subject to any oversight, and may no longer be fit for purpose.
+The [Attic](https://attic.apache.org) contains historic code that is no longer maintained.
+We make no guarantees as to whether it can still be used as it was originally intended.
+A project in the [Attic](https://attic.apache.org) is not subject to our various security- and release-policies.
+It is no longer considered a release by the Apache Software Foundation, is not subject to any oversight, and may no longer be fit for purpose.

--- a/content/blog/data-processing-compliance-statements-and-sla.md
+++ b/content/blog/data-processing-compliance-statements-and-sla.md
@@ -66,7 +66,7 @@ comes mainly from the transparency that we practice in all aspects of developmen
 # Attic
 
 The [Attic](https://attic.apache.org) contains historic code that is no longer maintained.
-We make no guarantees as to whether the code still works as originally intended we do not release new versions.
+We make no guarantees as to whether the code still works as originally intended and we do not release new versions.
 We no longer track security issues and other bugs for this code, and we will not provide fixes.
 
 In other words, a project in the [Attic](https://attic.apache.org) is not subject to our various security- and release policies.

--- a/content/blog/data-processing-compliance-statements-and-sla.md
+++ b/content/blog/data-processing-compliance-statements-and-sla.md
@@ -66,6 +66,8 @@ comes mainly from the transparency that we practice in all aspects of developmen
 # Attic
 
 The [Attic](https://attic.apache.org) contains historic code that is no longer maintained.
-We make no guarantees as to whether it can still be used as it was originally intended.
-A project in the [Attic](https://attic.apache.org) is not subject to our various security- and release policies.
+We make no guarantees as to whether the code still works as originally intended we do not release new versions.
+We no longer track security issues and other bugs for this code, and we will not provide fixes.
+
+In other words, a project in the [Attic](https://attic.apache.org) is not subject to our various security- and release policies.
 It is not subject to any oversight, its releases are no longer considered releases by the Apache Software Foundation, and they may no longer be fit for purpose.

--- a/content/blog/data-processing-compliance-statements-and-sla.md
+++ b/content/blog/data-processing-compliance-statements-and-sla.md
@@ -65,4 +65,4 @@ comes mainly from the transparency that we practice in all aspects of developmen
 
 # Attic
 
-The [Attic](https://attic.apache.org) contains historic code that is no longer maintained. We make no guarantees on whether it can still be used as it was originally intended. A project that was moved to the [Attic](https://attic.apache.org) is not subject to our various security- and release-policies. It is no longer considered a release by the Apache Software Foundation.
+The [Attic](https://attic.apache.org) contains historic code that is no longer maintained. We make no guarantees on whether it can still be used as it was originally intended. A project that was moved to the [Attic](https://attic.apache.org) is not subject to our various security- and release-policies. It is no longer considered a release by the Apache Software Foundation, is not subject to any oversight, and may no longer be fit for purpose.


### PR DESCRIPTION
The description of the attic in our 'SLA' statement reads a bit harsh, likely because we wrote it with the "entitled corporations making unreasonable requests" target audience in mind.

This changes it to make the Attic less 'scary-sounding' (indeed it is a 'natural' phase of a projects' lifecycle), while remaining clear on what (not) to expect.