### PR TITLE
Replace Camel security page with security model

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -31,7 +31,7 @@ To report a vulnerability in an Apache project that is not listed below, contact
 | Apache BookKeeper |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache bRPC |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache Calcite |  [Apache Security Team](mailto:security@apache.org) | |
-| [Apache Camel](https://camel.apache.org/security/) |  [Apache Security Team](mailto:security@apache.org) | [Advisories](https://camel.apache.org/security/) |
+| [Apache Camel](https://camel.apache.org/manual/security-model.html) |  [Apache Security Team](mailto:security@apache.org) | [Advisories](https://camel.apache.org/security/) |
 | [Apache Carbondata](https://carbondata.apache.org/security.html) |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache Cassandra |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache Causeway |  [Apache Security Team](mailto:security@apache.org) | |

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -31,7 +31,7 @@ To report a vulnerability in an Apache project that is not listed below, contact
 | Apache BookKeeper |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache bRPC |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache Calcite |  [Apache Security Team](mailto:security@apache.org) | |
-| [Apache Camel](https://camel.apache.org/manual/security-model.html) |  [Apache Security Team](mailto:security@apache.org) | [Advisories](https://camel.apache.org/security/) |
+| [Apache Camel](https://camel.apache.org/manual/security-model.html) |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache Carbondata](https://carbondata.apache.org/security.html) |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache Cassandra |  [Apache Security Team](mailto:security@apache.org) | |
 | Apache Causeway |  [Apache Security Team](mailto:security@apache.org) | |

--- a/content/projects/camel/_index.md
+++ b/content/projects/camel/_index.md
@@ -6,11 +6,11 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Camel? You can read more about the projects' security policy on their [security page](https://camel.apache.org/security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Camel? You can read more about the projects' security policy on their [security page](https://camel.apache.org/manual/security-model.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://camel.apache.org/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://camel.apache.org/manual/security-model.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Deserialization of Untrusted Data in Camel LevelDB ## { #CVE-2026-25747 }

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -56,7 +56,7 @@
   "camel": {
     "name": "Apache Camel",
     "link": "https://camel.apache.org/security/",
-    "advisory_link": "https://camel.apache.org/security/",
+    "advisory_link": "https://camel.apache.org/manual/security-model.html",
     "contact": "security@apache.org"
   },
   "carbondata": {

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -55,8 +55,8 @@
   },
   "camel": {
     "name": "Apache Camel",
-    "link": "https://camel.apache.org/security/",
-    "advisory_link": "https://camel.apache.org/manual/security-model.html",
+    "link": "https://camel.apache.org/manual/security-model.html",
+    "advisory_link": null,
     "contact": "security@apache.org"
   },
   "carbondata": {


### PR DESCRIPTION
Camel security page only contains a list of vulnerabilities, whereas linking to the security model would be more effective in reducing the number of false positives reported.