### PR TITLE
AI likes to give us Markdown attachments which are painful and annoying

### DIFF
--- a/content/report-code.md
+++ b/content/report-code.md
@@ -15,7 +15,7 @@ projects have published a 'Security Model' to clarify which guarantees can be
 expected. You can find the security model pages, as well as the email address
 you can use to report potential vulnerabilities, [here](/projects).
 
-Please send one plain-text, unencrypted, email for each vulnerability you are reporting to [security@apache.org](mailto:security@apache.org). We may ask you to resubmit your report if you send it as an image, movie, HTML, or PDF attachment when you could as easily describe it with plain text.
+Please send one plain-text, unencrypted, email for each vulnerability you are reporting to [security@apache.org](mailto:security@apache.org). We will reject your report and ask you to resubmit it if you send it as an image, movie, HTML, Markdown, or PDF attachment when you could as easily describe it with plain text.
 By sending your report to this address you agree that information from this report
 may be made public after triage (for invalid issues) or after the release of the fix,
 unless you explicitly request otherwise.


### PR DESCRIPTION
Also be more clear that we will just reject reports that have not paid attention to this rule about useless attachments.