### PR TITLE
add ant-cyclonedx SBOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ canonical locations.
 | TLP                                                                                                               | SBOMs                               | Build       | SBOM Tools | Comments
 | ------------------------------------------------------------------------------------------------------------------| ----------------------------------- | ----------- | ---------- | --------
 | [Airflow](https://airflow.apache.org/)       [:clipboard:](https://projects.apache.org/committee.html?airflow)    | [:mag:](sboms/README.md#airflow)    | pip<br>npm | cdxgen     | [SBOMs publication](https://airflow.apache.org/docs/apache-airflow/stable/security/sbom.html)
+| [Ant](https://ant.apache.org/)               [:clipboard:](https://projects.apache.org/committee.html?ant)        | [:mag:](sboms/README.md#ant)        | Ant       | Apache CycloneDX Antlib |
 | [Arrow](https://arrow.apache.org/)           [:clipboard:](https://projects.apache.org/committee.html?arrow)      | [:mag:](sboms/README.md#arrow)      | Maven<br>... | CDX Maven P | Go? Python?
 | [Avro](https://avro.apache.org/)             [:clipboard:](https://projects.apache.org/committee.html?avro)       | [:mag:](sboms/README.md#avro)       | Maven<br>... | CDX Maven P | Python, C/C++/C#, PHP, ...
 | [Camel](https://camel.apache.org/)           [:clipboard:](https://projects.apache.org/committee.html?camel)      | [:mag:](sboms/README.md#camel)      | Maven     | CDX Maven P |

--- a/sboms/README.md
+++ b/sboms/README.md
@@ -9,6 +9,9 @@ Apache Software Foundation produced SBOMs
 - 2.10.0: [21 SBOMs](airflow/airflow-2.10.0.md)
 - 2.10.2: [21 SBOMs](airflow/airflow-2.10.2.md)
 
+## Ant
+- 0.1: [1 SBOM](ant/ant-cyclonedx-0.1.md)
+
 ## Arrow
 - 11.0.0: [1 SBOM](arrow/arrow-11.0.0.md)
 - 15.0.2: [1 SBOM](arrow/arrow-15.0.2.md)

--- a/sboms/ant/ant-cyclonedx-0.1.md
+++ b/sboms/ant/ant-cyclonedx-0.1.md
@@ -1,0 +1,6 @@
+CycloneDX Antlib 0.1: 1 SBOM
+=======
+
+| file, spec<br>Serial Number, version| metadata | components<br>by type<br>- libs purl types |
+| ----------------------------------- | -------- | ------------------------------------------ |
+| **[ant-cyclonedx-0.1-cyclonedx](maven/org.apache.ant/ant-cyclonedx/0.1/ant-cyclonedx-0.1-cyclonedx.json)**<br>json CycloneDX 1.6<br>urn:uuid:9dd4fe71-e412-4d0d-99c8-b0a11286442f<br>version: 1 | **maven/org.apache.ant/ant-cyclonedx@0.1?type=jar**<br>type: LIBRARY<br>timestamp: 2026-05-31 16:38:42<br>tool: ant-cyclonedx 0.1 | 16<br>`library`: 16 <br>- `maven`: 16  |

--- a/sboms/ant/maven/org.apache.ant/ant-cyclonedx/0.1/ant-cyclonedx-0.1-cyclonedx.json
+++ b/sboms/ant/maven/org.apache.ant/ant-cyclonedx/0.1/ant-cyclonedx-0.1-cyclonedx.json
@@ -1,0 +1,1322 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:9dd4fe71-e412-4d0d-99c8-b0a11286442f",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2026-05-31T14:38:42Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : {
+      "components" : [
+        {
+          "type" : "library",
+          "supplier" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "manufacturer" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "publisher" : "The Apache Software Foundation",
+          "group" : "org.apache.ant",
+          "name" : "ant-cyclonedx",
+          "version" : "0.1",
+          "description" : "Apache CycloneDX Antlib",
+          "hashes" : [
+            {
+              "alg" : "MD5",
+              "content" : "f00bf8afd0fd1a4677a80aa400934230"
+            },
+            {
+              "alg" : "SHA-1",
+              "content" : "64676be7248fc2ec0eef936be9c2507909e05414"
+            },
+            {
+              "alg" : "SHA-256",
+              "content" : "a4f295746ba0ea50d7b720dc4f42ffbe5a98bc3ad9f0d175a0be80a5bd108e84"
+            },
+            {
+              "alg" : "SHA-512",
+              "content" : "b0fa0bc41af224339d3bd301fe308de3bd3b0f75ad7ded60559469fa4eed85bec96e0eb195ae1db14fad2a8aaed42c776b3268575d7feeac6751a7737193cf3c"
+            },
+            {
+              "alg" : "SHA3-256",
+              "content" : "8af81f7d1cda4165dd841ef06ef5fa928a103a2de487bc62e659f98618c6f8d7"
+            },
+            {
+              "alg" : "SHA3-512",
+              "content" : "5584260043593ad9abcd6b2c9630edc65422f6b4853cc884935d995d9f4a04c6be6ad4504a38f16910fbff698f5411cbe5bbab0ee071f6011eeef51a9fa93cdb"
+            },
+            {
+              "alg" : "SHA-384",
+              "content" : "3532c340f51512b3521f96fe1f96b49cb7748c2b117ca4670dad26db8842efced5a64a366af01be2a25940eac63acf3f"
+            },
+            {
+              "alg" : "SHA3-384",
+              "content" : "64b575e8e4c5f28d77fa55aa81f031c7fa7873ccda1ab3f4429e35587c3d33cc1f66bcb9e3caae1c0945f24ab722362c"
+            }
+          ],
+          "licenses" : [
+            {
+              "license" : {
+                "id" : "Apache-2.0",
+                "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+              }
+            }
+          ],
+          "purl" : "pkg:maven/org.apache.ant/ant-cyclonedx@0.1?type=jar",
+          "externalReferences" : [
+            {
+              "type" : "vcs",
+              "url" : "https://gitbox.apache.org/repos/asf/ant-antlibs-cyclonedx.git"
+            },
+            {
+              "type" : "license",
+              "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            },
+            {
+              "type" : "build-system",
+              "url" : "https://ci-builds.apache.org/job/Ant/job/CycloneDX%20Antlib/"
+            },
+            {
+              "type" : "mailing-list",
+              "url" : "https://ant.apache.org/mail.html"
+            },
+            {
+              "type" : "issue-tracker",
+              "url" : "https://bz.apache.org/bugzilla/buglist.cgi?component=CycloneDX%20Antlib&product=Ant"
+            },
+            {
+              "type" : "website",
+              "url" : "https://ant.apache.org/antlibs/cyclonedx/"
+            },
+            {
+              "type" : "distribution",
+              "url" : "https://ant.apache.org/antlibs/bindownload.cgi"
+            },
+            {
+              "type" : "source-distribution",
+              "url" : "https://ant.apache.org/antlibs/srcdownload.cgi"
+            },
+            {
+              "type" : "security-contact",
+              "url" : "https://www.apache.org/security/"
+            }
+          ]
+        }
+      ]
+    },
+    "component" : {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant-cyclonedx@0.1?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "manufacturer" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.ant",
+      "name" : "ant-cyclonedx",
+      "version" : "0.1",
+      "description" : "Apache CycloneDX Antlib",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f00bf8afd0fd1a4677a80aa400934230"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "64676be7248fc2ec0eef936be9c2507909e05414"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a4f295746ba0ea50d7b720dc4f42ffbe5a98bc3ad9f0d175a0be80a5bd108e84"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b0fa0bc41af224339d3bd301fe308de3bd3b0f75ad7ded60559469fa4eed85bec96e0eb195ae1db14fad2a8aaed42c776b3268575d7feeac6751a7737193cf3c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8af81f7d1cda4165dd841ef06ef5fa928a103a2de487bc62e659f98618c6f8d7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5584260043593ad9abcd6b2c9630edc65422f6b4853cc884935d995d9f4a04c6be6ad4504a38f16910fbff698f5411cbe5bbab0ee071f6011eeef51a9fa93cdb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3532c340f51512b3521f96fe1f96b49cb7748c2b117ca4670dad26db8842efced5a64a366af01be2a25940eac63acf3f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "64b575e8e4c5f28d77fa55aa81f031c7fa7873ccda1ab3f4429e35587c3d33cc1f66bcb9e3caae1c0945f24ab722362c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant-cyclonedx@0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant-antlibs-cyclonedx.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/job/CycloneDX%20Antlib/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?component=CycloneDX%20Antlib&product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/antlibs/cyclonedx/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/antlibs/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/antlibs/srcdownload.cgi"
+        }
+      ]
+    },
+    "manufacturer" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "supplier" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "licenses" : [
+      {
+        "license" : {
+          "id" : "Apache-2.0",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      }
+    ]
+  },
+  "components" : [
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant@1.10.17?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant",
+      "version" : "1.10.17",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant@1.10.17?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant-launcher@1.10.17?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant-launcher",
+      "version" : "1.10.17",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant-launcher@1.10.17?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@12.2.0?type=jar",
+      "publisher" : "OWASP Foundation",
+      "group" : "org.cyclonedx",
+      "name" : "cyclonedx-core-java",
+      "version" : "12.2.0",
+      "description" : "The CycloneDX core module provides a model representation of the BOM along with utilities to assist in creating, parsing, and validating BOMs.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dc705afed6dfeedf19d94696a97c88fe"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3dc57637a94138634eeb436ff9d48f88c36d6cbc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f420af2e5c406f8dfff3f279cf3ce9f0539a27f895e8d80dd291c7fafd0c5ff8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "366df28df4bcd990c1ca82efe507ceea994c5131e463421142a45e266f69437a8ad1e4a2acd4621838fdf3c39ed856b97aa169cfe3d7d574d22dd32c93b294e2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a56cc9756717ef1471f328d9de6e77f139c91ebdf22d2dee8e4a0875e92aa1d8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e16cac9fb123773a2342afc14a81b642a6d1d18ce11fec3cb5eee9f0ad9e2a210c9a089f51a9c2d9010d6e69523bff40e51400c8e04dc561c19269cfe795d929"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4ff512c3935021762e37e3bde9ce03eb8f7edd88f90c091d04ffdd8c8f09da8b7feeb687c6d1c439ac004421ca21bd85"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f266d407fead702bbc562912009d370814fa21c6aa3950b152f805ee583c9a5e44ab7315d2a91dec3e83856e048392b8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@12.2.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-codec/commons-codec@1.21.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-codec",
+      "name" : "commons-codec",
+      "version" : "1.21.0",
+      "description" : "The Apache Commons Codec component contains encoders and decoders for formats such as Base16, Base32, Base64, digest, and Hexadecimal. In addition to these widely used encoders and decoders, the codec package also maintains a collection of phonetic encoding utilities.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c49977029838babaf8a71485aa9aaef8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d95f998db5f89900fe895daf6cd2cddcb2f1d64b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4da851cb6abfb98bfe9eb77c5e5fc47f5414fa28b94e21b7fd9a646705dc167f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3ceb4aa588d0b918e46b1ddda9ff41b5a765985bf66542d2728458fc3f83b9dedfd972ff5d919cf6f456fbaa9f8c4e5f0c0913848ec3a471c316374e683b1f2a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cbc2eafcba305c08e852133d0881d209799c4dc83d587869eed5f281d6bed4f3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "244e6a342d4b5a6e7d077426427979f26320be305f1cb33d933672c926ea3a96fe4f284c9f592970f604928209fe0e149613b64990202d595bce01a669de418b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "05786582b0a85264688ad5b49ad6da09db1cdfe6301cf31ddea48f97f45b13ff25d9e3def1702890457fd5bbbd00f793"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "805bda170837bbedbecc5c63a5defc6a348777952906d8e6f33544866e86aa25c9d28f3b351e981d0fa49bb16e07884c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-codec/commons-codec@1.21.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-codec/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-codec/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/CODEC"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/commons-codec"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-io/commons-io@2.21.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-io",
+      "name" : "commons-io",
+      "version" : "2.21.0",
+      "description" : "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bc7e020873f086ede85f97bd9f013215"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "52a6f68fe5afe335cde95461dd5c3412f04996f7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7d643a2afea8b058b762aa6fb90e5b256f6c729739f8b3784c3370ddc609e88d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7ac1aa4d834cd7cdecaee223a64c63d481810c73dfdb5109f402234a05cadf754e414cead99072f5140d4f7042ee084161935fb28129a631d908d989c5bbac5d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1f8f4ce25b7169452dabb10ce843b3246378ea55c1971acd2300e417747b3a68"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "175630adf10305aeb31d737f833021a25582ffe2ef66fda6e7f694598af9c68cebbd205ade469eca4faaf6b9d349244289e62179d9cf48d93427090e2c008cf8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "97c07e5c4f62484c98b6777f63ab032ee09eeb1c9ddae8332890126df9c665afb9cd554db02495171738720d23c53732"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e3e44c9f4a5f4075fb62a438a84015fe2abf878e9793835a7816dc3c35141bb79fe96dfdc6bb5aef96b7c5bbbcf453c1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-io/commons-io@2.21.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-io/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-io/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/IO"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-io.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-lang3@3.20.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.20.0",
+      "description" : "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang. The code is tested using the latest revision of the JDK for supported LTS releases: 8, 11, 17, 21 and 25 currently. See https://github.com/apache/commons-lang/blob/master/.github/workflows/maven.yml Please ensure your build environment is up-to-date and kindly report any build issues.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4b29562ded527aa074e1d44f8646dac5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "65897b3e5731220962e659e001904af3c3cbeba9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "69e5c9fa35da7a51a5fd2099dfe56a2d8d32cf233e2f6d770e796146440263f4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1c72db334ea44f932c35e602b78907865f5bab43e30c871c9be67c8184eaa778f32d7bc3ab525d5921cd28619d3f9babfd483f17de54f007ee07db2e074b0307"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "36e3f71352fa14bc580db45a05b09b063392c6d39acf9e24ffa6a67bbc07a336"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6ecbc05bb5cd3f7537078b0cf51b0a5f7189dfa60c22e5ec0d6b9e2fd3f7fa7566770b5da87e0c9929f48769933c3e3a473fd5cc7231672fca36ab1fee1f8670"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "77dd27c4d5e9372c002bd6878d2cfaaec3cf46dd57d65de63d7f2e09351344531cfa81a537b56628ac6db18adee7e484"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3456de40eef224b3ad195d2f218dd28eacb0da07607aee7ead94bd8d54bd8311d51c28d4066db4bf8b69a2df48c415f5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.20.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-lang/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-lang/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LANG"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/commons-lang.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-collections4@4.5.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-collections4",
+      "version" : "4.5.0",
+      "description" : "The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d564105594035b363b193d8ce3c18b98"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e5cf89f0c6e132fc970bd9a465fdcb8dbe94f75a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "00f93263c267be201b8ae521b44a7137271b16688435340bf629db1bac0a5845"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ee43c513ac9dcbd7dd23b5cbb4ea5f65a2e10cdfbb403d080b87e778b3b45062315522297c41eca514a9a946228ad7650f0a572d5b78effb8260dd8084131988"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "614c41bfd8f9c6c1c1e5667c5be45587c3021b780937ad62f54d17051f425086"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3cfd12ec2d03ed29b682123cedae422a4c6dc459034a7e0ab5f00ccd422cb9a2ec423a08b953119c426569b888157a6d80aa0e0c63debea50c5c54c481e2eff5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "73db8eb3e79569b3fa62aefdce413e6ea250b9853953cb75b9d5ce0f2f35b59b6e86ef708326a608ff20d95bdade8522"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7a9c035fa846cdcebd4331eb86ed31a67595518299a8bee54597c1eb663aee63214553a561a510b929035266c2a4800b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-collections4@4.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-collections/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/COLLECTIONS"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-collections.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "group" : "com.github.package-url",
+      "name" : "packageurl-java",
+      "version" : "1.5.0",
+      "description" : "The official Java implementation of the PackageURL specification. PackageURL (purl) is a minimal specification for describing a package via a \"mostly universal\" URL",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "90856d8bb5b17e08fdf03b6a2f93b81c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e6bf530f52feab911f4032604ca0b8216f7ff337"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e45551727707acc0c56ac62d56964332ea0f138d6cc3656d988b9369150f5247"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8064df400154caa110b8845bd17e6cea2683307e575ce88e40d7c0c8965ea0af6c150a376d8b9ba7354676c41b52c94535f30c6e830447613299ccf5fc7aa959"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c9881b69bde35ea6ff4006877b9fbf91462f911b5b142aa699a45a00867d413a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2b9caf58deef687a9bf01abd61a7af4abdb61247a8a966683a18157ee948f1ea424602598dc8f665bf24f7e1e516866298ef0507e9d697cb20dcf60eff2095ca"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0597100022f72e020c9d929bf57ecef91af7574610fb03b4019feba4b25f491a076f03577be2009e66d9001c4c0f8ab0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bbdd55a31a4755ef589bcb176283fe03e3c9089d315eab577fef3a9c2d02e632c6ac3fdebbc90a2f0f8ed7974b9f397c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.21.1?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.dataformat",
+      "name" : "jackson-dataformat-xml",
+      "version" : "2.21.1",
+      "description" : "Data format extension for Jackson to offer alternative support for serializing POJOs as XML and deserializing XML as POJOs.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d9120cfeab371bded24af440a8f6415a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "73226950371cac1fb361b7ea217db52f9f3fdfb6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "93b9fb7d4d3f8b0f6876f50f3bf4931c28ed1a6aedbce93c52749068c38ab092"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b2cc9fb0d3816368d6601fc4bdbc0cbb9a02757c4637a0aa53dd4f1872bf3719956d6bdd46ad4e5e822b5219ff3957882a36fc55bcf91340a2c781b5d4d971cc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e41aacbc675ee973178e025fd551baf286756c29f543de5f9d484211a2f6686c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c44c13f2326143e7e058754a7bf785db372ec77824c3661393419916dfb683ec2d506ba1664fd3c88e719a64f9c417f04fdc844ed3535816aca79c46ed112f66"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5e3618565af79fe4d6a749495c08a09937190ff1c60f660a8b41c7875067747169d238dd72751c35f659666caf3711af"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4378d4100f38ca2e2a2791ca0a6f434bd73d3175b3ddbfaa361f94ea50915d0018dd95e03d50cef47b2f80668dad38f2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.21.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-dataformat-xml"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://central.sonatype.com/api/v1/publisher"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-dataformat-xml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-dataformat-xml"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.1?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.21.1",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a526a530a07fd25140dee4695e686051"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "47b013fc85dbb819f3ba51e95a5560d0f1c4121c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1edd5f2e49dca5f8e4519957c24b7b3050bd1c7ee883920da33cff031ff1f7c0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f4b153a0a7c974620dec3fcfe4a4869c2632ab97f73c2662041af7d0eb0c42ad462bfee8cdcab5542842175b96197df1d910a8841067654f6e763b370c18ccfa"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a39b1a208b640982042b4ad6f7606a7b6ea537d23034fafd7d3330252e85c178"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a712ad471cd591149a8d9e8d2ad1795915d1098332d521c32be26e76ea9b18eb84d22d3dd1dd3f008bfb223b89d7a6c33cd621385933735f67d758cb191be9ca"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "22047a20191a34eba9c83e3b6d5df5b74b160eea9c5279e3d32d7688e2dcdd791083db1d661ebb7aaf872fe603460f30"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "44632cb6d9783d4dd883081507ff220c19bd620041791e8f1e63671aa57400d2bc03af732a9a12728b5918e4e7a415e2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://central.sonatype.com/api/v1/publisher"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-core/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.21?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-annotations",
+      "version" : "2.21",
+      "description" : "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e0d0c3e7300954f73e43c67d933aaea4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b1bc1868bf02dc0bd6c7836257a036a331005309"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "53ca085f4a150f703f49e1aabd935bd03b43e1ea3d55d135438292af22cef56b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d832a99867acc2d5afb2596da760c50e6a6b54c1bbc8e6c4186f267a16e1d55c7a916ef8b034ad6b277c41e3342b91dcdc2e3dcea8bdccfe89e7c147894591be"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d6782d188a72b2bb96e4b595343e783012b3f98c30f7b9950244c21739334509"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b648f1e9ffe818227d53fbde409e61858ac22d3f78705eaf08065587ed512c9b33b0f5e2222356bfb33fb2973bb5a3184e31d2a7099f8fc8d2fd23eb4612a4bf"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "30b15d68f8da6f6c26aa9f6c95d09152b6c1a8092cd976cf600d63d1751509a73865f937e0ad97d8d55bf20f6a749b44"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5205b51f6ed689cf31b58b98a61ca9e17a439c15d669dcb408ec4d430e77ac9ac57d39d5ca1f9973e8d184f6dd57ec4f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.21?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://central.sonatype.com/api/v1/publisher"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-annotations/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-annotations"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.21.1?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-databind",
+      "version" : "2.21.1",
+      "description" : "General data-binding functionality for Jackson: works on core streaming API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "35fe6cc9ff7990e67f86a92092aa0569"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5615fb77652bfd386d87b95a1d663e1c0e38b372"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b011eb5202d9ec889e27f1dcbdf6c63f06a76e7a16c0a1b30c6048d556c9a28e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "837a94e20474d0ad3630663c0112e982914e5cfa3bbf397b8c31d00b68d7fc8e4514458b75dd39cf74edda7e33339504fa845864476786e94812bd36a5a428ee"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fb7b4d84416fc38f1b90b3e4dcd4ad6ffe484e4092530ac459d18b48a146479d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "17eb42ce90e339d66509adbb429296eafd283c72229c81deec2ca78e9e941c692b4ace7595f0fe5c5eb54b5bac93c7b3ab146be992ba9d974d2e388a2a964543"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "42101498ef71f5b506c2b445217722949c57f634bc7cd5ca4a7d112faa8edb98b9ff1cce06a23d65389315da0e79cc31"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0ca6e7f95c5600ff88712faec79a9f45438908abfdbb9367ceef7e3ccf37256212db617509fc68efae0d919418210777"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.21.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://central.sonatype.com/api/v1/publisher"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-databind/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-databind"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@7.1.1?type=jar",
+      "group" : "com.fasterxml.woodstox",
+      "name" : "woodstox-core",
+      "version" : "7.1.1",
+      "description" : "Woodstox is a high-performance XML processor that implements Stax (JSR-173), SAX2 and Stax2 APIs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "971ff236679f7b35a7c13c0d02c0170e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "76baad1b94513ea896e0a17388890a4c81edd0e0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "02b9d022e9d47704ff8a7a859a0dbfd3b2882a8311eb7ff1e180f760ccda2712"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "28105d6409766966123d4e212dba555c4776bfeb538093d3739ef113de5c6d6e92453aabc16915bfb76124a5dcc82b57f3cd13b42ea2e4038a4495285c642d3a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "10a216995fc4e318dcb0be7b9ae00c07536fbc81e6119f0bf1e36716146f674d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "924b1cb6ba79666c4fc13f1b057b376de471cfe60e68daca71ed51355abbd0de6799441ddd81df786317dd2c533cc1d3a9671f759e3a480d99c2d772eaa5ddda"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca02f505f335a975e71c4a549bc3707c35b3592d2ac2fc2cf8887dfde44ae76b753ad2174e4971bb33bb1ab6c8c6b3c7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1efac262497c761e493337361dbc388ac01634dbda5322a8ee7742b0b25a26cc039c3e3653bf2302fbc31883c8030703"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@7.1.1?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.networknt/json-schema-validator@2.0.1?type=jar",
+      "group" : "com.networknt",
+      "name" : "json-schema-validator",
+      "version" : "2.0.1",
+      "description" : "A json schema validator that supports draft v4, v6, v7, v2019-09 and v2020-12",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "656de95acd16444a86fc85f39852f8ac"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f770b48b7423e576c47b8a703840fddde325b29c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "216fa6f496d4390ec6ba208593ad91d3a6fae21b7f5d8d327c4d628946ff9ea6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8327fe60c0c975d377de22d978d2bca2707e5fe7a98df2feb21a0db22e54b234a62c5df2f3c45f50a89db7dc811f74e1d9e89a93d592ae1ea2adafc25c770dd2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "64905fb32112d97cf47db3f80ce3f1112e235f730474a346ffb9da9223026c96"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8251a014dcefceb2ecd2c02e5ed0b158d5a5fa1ab26028a4913cf871fbc5455e967de94c60f7eb0f3ecc1ff3aa41a41c72c68a3234b93a196b7357c528cca6d2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "00aeb3ba3abaa2c34a46e8aedc9c6fe63b432fd0e17e0ad552a8f0c13302e8b46ff9df769afde58e7f1ab4e94415f601"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cd9a4b789bc3f84b48040a775c99a68513ceb8300f9bd1aa51c0612eb8364ca0c9515b2e7cea8b274db6f4f9d9d28c76"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.networknt/json-schema-validator@2.0.1?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar",
+      "publisher" : "fasterxml.com",
+      "group" : "org.codehaus.woodstox",
+      "name" : "stax2-api",
+      "version" : "4.2.2",
+      "description" : "Stax2 API is an extension to basic Stax 1.0 API that adds significant new functionality, such as full-featured bi-direction validation interface and high-performance Typed Access API.",
+      "scope" : "required",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/stax2-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/stax2-api/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/stax2-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.randelshofer/fastdoubleparser@2.0.1?type=jar",
+      "group" : "ch.randelshofer",
+      "name" : "fastdoubleparser",
+      "version" : "2.0.1",
+      "description" : "A Java port of Daniel Lemire's fast_float project.",
+      "scope" : "required",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.randelshofer/fastdoubleparser@2.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/wrandelshofer/FastDoubleParser"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/wrandelshofer/FastDoubleParser/tree/master"
+        }
+      ]
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant-cyclonedx@0.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant@1.10.17?type=jar",
+        "pkg:maven/org.cyclonedx/cyclonedx-core-java@12.2.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant@1.10.17?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant-launcher@1.10.17?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant-launcher@1.10.17?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@12.2.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-codec/commons-codec@1.21.0?type=jar",
+        "pkg:maven/commons-io/commons-io@2.21.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.20.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-collections4@4.5.0?type=jar",
+        "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.21.1?type=jar",
+        "pkg:maven/com.networknt/json-schema-validator@2.0.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-codec/commons-codec@1.21.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/commons-io/commons-io@2.21.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-lang3@3.20.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-collections4@4.5.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-codec/commons-codec@1.21.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.21.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.1?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.21?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.21.1?type=jar",
+        "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar",
+        "pkg:maven/com.fasterxml.woodstox/woodstox-core@7.1.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.randelshofer/fastdoubleparser@2.0.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.21?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.21.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.21?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.1?type=jar"
+      ]
+    }
+  ]
+}

--- a/scripts/collect-sboms-from-maven-central.py
+++ b/scripts/collect-sboms-from-maven-central.py
@@ -112,6 +112,8 @@ elif pmc == 'turbine':
     projects = maven_projects(pmc) + maven_projects(pmc, prefix = "org/apache/fulcrum")
 elif pmc == 'wc':
     projects = maven_projects(pmc) + maven_projects(pmc, prefix = "org/apache/wss4j")
+elif pmc == 'ant':
+    projects = maven_projects(pmc) + maven_projects(pmc, prefix = "org/apache/ivy")
 else:
     projects = maven_projects(pmc)
 

--- a/scripts/describe-sboms.sh
+++ b/scripts/describe-sboms.sh
@@ -80,6 +80,8 @@ function describeReleasesFromBaseStrict() {
 
 describeReleasesFromBasedir airflow Airflow - apache-airflow
 
+describeReleasesFromBase ant "CycloneDX Antlib" ant-cyclonedx org.apache.ant -
+
 describeReleasesFromBase arrow Arrow -
 describeReleasesFromBase avro Avro -
 describeReleasesFromBase camel Camel -

--- a/scripts/describe_sboms.java
+++ b/scripts/describe_sboms.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.cyclonedx:cyclonedx-core-java:8.0.3
+//DEPS org.cyclonedx:cyclonedx-core-java:12.2.0
 //DEPS org.apache.maven:maven-artifact:3.9.9
 
 import java.io.File;
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
-import org.cyclonedx.BomGeneratorFactory;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
 import org.cyclonedx.model.Bom;

--- a/scripts/sboms-from-maven-central.json
+++ b/scripts/sboms-from-maven-central.json
@@ -1,4 +1,5 @@
 [
+  "ant",
   "arrow",
   "avro",
   "commons",


### PR DESCRIPTION
This is the first release of any component of the Ant project to include an SBOM - and the SBOM has been created by the component itself.

I've got no idea whether the markdown files are auto-generated from the SBOM but the last PRs I looked at only added the SBOMs themselves.