### PR TITLE
Update Apache APISIX security page link

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -19,7 +19,7 @@ To report a vulnerability in an Apache project that is not listed below, contact
 | Apache Ambari |  [Apache Ambari Security Team](mailto:security@ambari.apache.org) | |
 | [Apache Answer](https://answer.apache.org/community/security-model) |  [Apache Security Team](mailto:security@apache.org) | [Advisories](https://answer.apache.org/community/security/) |
 | [Apache Ant](https://ant.apache.org/security.html) |  [Apache Security Team](mailto:security@apache.org) | |
-| [Apache APISIX](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md) |  [Apache Security Team](mailto:security@apache.org) | |
+| [Apache APISIX](https://apisix.apache.org/docs/apisix/security-threat-model/) |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache Portable Runtime (APR)](https://apr.apache.org/security_report.html) |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache Arrow](https://arrow.apache.org/docs/dev/format/Security.html) |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache Artemis](https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc) |  [Apache Security Team](mailto:security@apache.org) | [Advisories](https://artemis.apache.org/components/artemis/security) |

--- a/content/projects/apisix/_index.md
+++ b/content/projects/apisix/_index.md
@@ -6,11 +6,11 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache APISIX? You can read more about the projects' security policy on their [security page](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache APISIX? You can read more about the projects' security policy on their [security page](https://apisix.apache.org/docs/apisix/security-threat-model/), and email your report to the [Apache Security Team](mailto:security@apache.org).
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://apisix.apache.org/docs/apisix/security-threat-model/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Improper authentication in cas-auth plugin ## { #CVE-2026-49872 }

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -15,7 +15,7 @@
   },
   "apisix": {
     "name": "Apache APISIX",
-    "link": "https://github.com/apache/apisix/blob/master/THREAT_MODEL.md",
+    "link": "https://apisix.apache.org/docs/apisix/security-threat-model/",
     "advisory_link": null,
     "contact": "security@apache.org"
   },


### PR DESCRIPTION
## Summary

Update the Apache APISIX security page link to point at the project's
security threat model page, and regenerate the affected pages.

- `link`: `https://github.com/apache/apisix/blob/master/THREAT_MODEL.md` -> `https://apisix.apache.org/docs/apisix/security-threat-model/`
- Regenerated `content/projects/_index.md` and `content/projects/apisix/_index.md` via `scripts/project-page.py`.

## Note

> [!NOTE]
> Stacked on top of #64. Review/merge that PR first; the base of this PR
> will retarget to `main` automatically once #64 merges.