### PR TITLE
Add Apache Jena threat model link

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -77,7 +77,7 @@ To report a vulnerability in an Apache project that is not listed below, contact
 | Apache IoTDB |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache Jackrabbit](https://jackrabbit.apache.org/jcr/security-reports.html) |  [Apache Jackrabbit Security Team](mailto:security@jackrabbit.apache.org) | [Advisories](https://jackrabbit.apache.org/jcr/security-reports.html) |
 | Apache James |  [Apache Security Team](mailto:security@apache.org) | |
-| Apache Jena |  [Apache Security Team](mailto:security@apache.org) | |
+| [Apache Jena](https://github.com/apache/jena/blob/main/THREAT_MODEL.md) |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache JMeter](https://jmeter.apache.org/security.html) |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache Johnzon](https://johnzon.apache.org/security.html) |  [Apache Security Team](mailto:security@apache.org) | |
 | [Apache JSPWiki](https://jspwiki-wiki.apache.org/Wiki.jsp?page=Security) |  [Apache Security Team](mailto:security@apache.org) | [Advisories](https://jspwiki-wiki.apache.org/Wiki.jsp?page=CVE) |

--- a/content/projects/jena/_index.md
+++ b/content/projects/jena/_index.md
@@ -6,11 +6,11 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Jena? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Jena? You can read more about the projects' security policy on their [security page](https://github.com/apache/jena/blob/main/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/jena/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Configuration files uploaded by administrative users are not check properly ## { #CVE-2025-50151 }

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -278,6 +278,12 @@
     "advisory_link": "https://jackrabbit.apache.org/jcr/security-reports.html",
     "contact": "security@jackrabbit.apache.org"
   },
+  "jena": {
+    "name": "Apache Jena",
+    "link": "https://github.com/apache/jena/blob/main/THREAT_MODEL.md",
+    "advisory_link": null,
+    "contact": "security@apache.org"
+  },
   "jmeter": {
     "name": "Apache JMeter",
     "link": "https://jmeter.apache.org/security.html",


### PR DESCRIPTION
Add a `jena` entry to `scripts/project-coordinates.json` pointing at the project's [THREAT_MODEL.md](https://github.com/apache/jena/blob/main/THREAT_MODEL.md), and regenerate the project pages.

## Changes
- `scripts/project-coordinates.json`: new `jena` entry with the threat model link (Jena previously had no coordinates entry and fell back to committees.json with no security link).
- `content/projects/_index.md` and `content/projects/jena/_index.md`: regenerated so Jena links to the threat model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)