### PR TITLE
Refactor project-coordinates: security_model_link and AI-friendly sources

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -55,7 +55,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
   - Advisories:\
     [activemq.apache.org](https://activemq.apache.org/security-advisories)
   - Security page:\
-    [github.com](https://github.com/apache/activemq/blob/main/SECURITY.md)
+    [github.com](https://github.com/apache/activemq/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/age/default.png" alt="" loading="lazy"> **Apache AGE**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AGE)
@@ -554,7 +554,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
   - Advisories:\
     [httpd.apache.org](https://httpd.apache.org/security/vulnerabilities_24.html)
   - Security page:\
-    [github.com](https://github.com/apache/httpd/blob/trunk/SECURITY.md)
+    [github.com](https://github.com/apache/httpd/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/httpcomponents/default.png" alt="" loading="lazy"> **Apache HttpComponents**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20HttpComponents)
@@ -602,7 +602,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
   - Advisories (experimental):\
     [security.apache.org](/projects/impala/)
   - Security page:\
-    [github.com](https://github.com/apache/impala/blob/master/SECURITY.md)
+    [github.com](https://github.com/apache/impala/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/inlong/default.png" alt="" loading="lazy"> **Apache InLong**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20InLong)
@@ -912,7 +912,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
   - Advisories (experimental):\
     none so far
   - Security page:\
-    [github.com](https://github.com/apache/paimon/blob/master/SECURITY.md)
+    [github.com](https://github.com/apache/paimon/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/parquet/default.png" alt="" loading="lazy"> **Apache Parquet**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Parquet)
@@ -1203,7 +1203,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
   - Advisories:\
     [superset.apache.org](https://superset.apache.org/docs/security/cves)
   - Security page:\
-    [github.com](https://github.com/apache/superset/blob/master/.github/SECURITY.md)
+    [github.com](https://github.com/apache/superset/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/synapse/default.png" alt="" loading="lazy"> **Apache Synapse**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Synapse)

--- a/content/projects/activemq/_index.md
+++ b/content/projects/activemq/_index.md
@@ -6,11 +6,11 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ActiveMQ? You can read more about the projects' security policy on their [security page](https://github.com/apache/activemq/blob/main/SECURITY.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ActiveMQ? You can read more about the projects' security policy on their [security page](https://github.com/apache/activemq/security/policy), and email your report to the [Apache Security Team](mailto:security@apache.org).
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/activemq/blob/main/SECURITY.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/activemq/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Temporary destination ownership takeover ## { #CVE-2026-54475 }

--- a/content/projects/httpd/_index.md
+++ b/content/projects/httpd/_index.md
@@ -6,11 +6,11 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HTTP Server? You can read more about the projects' security policy on their [security page](https://github.com/apache/httpd/blob/trunk/SECURITY.md), and email your report to the [Apache HTTP Server Security Team](mailto:security@httpd.apache.org).
+Do you want disclose a potential security issue for Apache HTTP Server? You can read more about the projects' security policy on their [security page](https://github.com/apache/httpd/security/policy), and email your report to the [Apache HTTP Server Security Team](mailto:security@httpd.apache.org).
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/httpd/blob/trunk/SECURITY.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/httpd/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## mod_http2 denial of service ## { #CVE-2026-49975 }

--- a/content/projects/impala/_index.md
+++ b/content/projects/impala/_index.md
@@ -6,11 +6,11 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Impala? You can read more about the projects' security policy on their [security page](https://github.com/apache/impala/blob/master/SECURITY.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Impala? You can read more about the projects' security policy on their [security page](https://github.com/apache/impala/security/policy), and email your report to the [Apache Security Team](mailto:security@apache.org).
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/impala/blob/master/SECURITY.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/impala/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Impala logs contain secrets ## { #CVE-2021-28131 }

--- a/content/projects/superset/_index.md
+++ b/content/projects/superset/_index.md
@@ -6,11 +6,11 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Superset? You can read more about the projects' security policy on their [security page](https://github.com/apache/superset/blob/master/.github/SECURITY.md), and email your report to the [Apache Superset Security Team](mailto:security@superset.apache.org).
+Do you want disclose a potential security issue for Apache Superset? You can read more about the projects' security policy on their [security page](https://github.com/apache/superset/security/policy), and email your report to the [Apache Superset Security Team](mailto:security@superset.apache.org).
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/superset/blob/master/.github/SECURITY.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/superset/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## SQLLab Read-Only Bypass on PostgreSQL ## { #CVE-2026-23984 }

--- a/scripts/check-coordinates-with-doap.py
+++ b/scripts/check-coordinates-with-doap.py
@@ -29,7 +29,8 @@ def fetch_doap(url):
 
 # manually maintained
 with open('project-coordinates.json', 'r') as p:
-    project_coordinates = json.load(p)
+    # Drop editor-only meta keys (e.g. "$schema"); every remaining key is a project.
+    project_coordinates = {k: v for k, v in json.load(p).items() if not k.startswith('$')}
 
 from rdflib.namespace import DefinedNamespace, Namespace
 from rdflib.term import URIRef

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -1,14 +1,17 @@
 {
+  "$schema": "./project-coordinates.schema.json",
   "accumulo": {
     "name": "Apache Accumulo",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/accumulo/default.png"
   },
   "activemq": {
     "name": "Apache ActiveMQ",
-    "link": "https://github.com/apache/activemq/blob/main/SECURITY.md",
+    "security_model_link": "https://github.com/apache/activemq/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/activemq/main/SECURITY.md",
     "advisory_link": "https://activemq.apache.org/security-advisories",
     "contact": "security@apache.org",
     "contributing": "https://activemq.apache.org/contributing",
@@ -16,21 +19,24 @@
   },
   "age": {
     "name": "Apache AGE",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/age/default.png"
   },
   "airavata": {
     "name": "Apache Airavata",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/airavata/default.png"
   },
   "airflow": {
     "name": "Apache Airflow",
-    "link": "https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html",
+    "security_model_link": "https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@airflow.apache.org",
     "contributing": "https://airflow.apache.org/community/",
@@ -38,21 +44,24 @@
   },
   "allura": {
     "name": "Apache Allura",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/allura/default.png"
   },
   "ambari": {
     "name": "Apache Ambari",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@ambari.apache.org",
     "logo_link": "https://www.apache.org/logos/res/ambari/default.png"
   },
   "answer": {
     "name": "Apache Answer",
-    "link": "https://answer.apache.org/community/security-model",
+    "security_model_link": "https://answer.apache.org/community/security-model",
+    "security_model_source": null,
     "advisory_link": "https://answer.apache.org/community/security/",
     "contact": "security@apache.org",
     "contributing": "https://answer.apache.org/community/contributing",
@@ -60,118 +69,138 @@
   },
   "ant": {
     "name": "Apache Ant",
-    "link": "https://ant.apache.org/security.html",
+    "security_model_link": "https://ant.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/ant/default.png"
   },
   "apisix": {
     "name": "Apache APISIX",
-    "link": "https://github.com/apache/apisix/blob/master/THREAT_MODEL.md",
+    "security_model_link": "https://github.com/apache/apisix/blob/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/apisix/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/apisix/default.png"
   },
   "apr": {
     "name": "Apache Portable Runtime (APR)",
-    "link": "https://apr.apache.org/security_report.html",
+    "security_model_link": "https://apr.apache.org/security_report.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/apr/default.png"
   },
   "archiva": {
     "name": "Apache Archiva",
-    "link": "https://archiva.apache.org/security.html",
+    "security_model_link": "https://archiva.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://archiva.apache.org/security.html",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/archiva/default.png"
   },
   "aries": {
     "name": "Apache Aries",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/aries/default.png"
   },
   "arrow": {
     "name": "Apache Arrow",
-    "link": "https://arrow.apache.org/docs/dev/format/Security.html",
+    "security_model_link": "https://arrow.apache.org/docs/dev/format/Security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/arrow/default.png"
   },
   "artemis": {
     "name": "Apache Artemis",
-    "link": "https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc",
+    "security_model_link": "https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc",
+    "security_model_source": "https://raw.githubusercontent.com/apache/artemis/main/docs/user-manual/threat-model.adoc",
     "advisory_link": "https://artemis.apache.org/components/artemis/security",
     "contact": "security@apache.org",
-    "contributing": "https://artemis.apache.org/contributing"
+    "contributing": "https://artemis.apache.org/contributing",
+    "logo_link": null
   },
   "asterixdb": {
     "name": "Apache AsterixDB",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/asterixdb/default.png"
   },
   "atlas": {
     "name": "Apache Atlas",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/atlas/default.png"
   },
   "avro": {
     "name": "Apache Avro",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/avro/default.png"
   },
   "axis": {
     "name": "Apache Axis",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
-    "contributing": "https://avro.apache.org/community/"
+    "contributing": "https://avro.apache.org/community/",
+    "logo_link": null
   },
   "baremaps": {
     "name": "Apache Baremaps",
-    "link": "https://github.com/apache/incubator-baremaps/blob/main/SECURITY.md",
+    "security_model_link": "https://github.com/apache/incubator-baremaps/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/incubator-baremaps/main/SECURITY.md",
     "advisory_link": null,
-    "contact": "security@apache.org"
+    "contact": "security@apache.org",
+    "logo_link": null
   },
   "beam": {
     "name": "Apache Beam",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/beam/default.png"
   },
   "bigtop": {
     "name": "Apache Bigtop",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/bigtop/default.png"
   },
   "bookkeeper": {
     "name": "Apache BookKeeper",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/bookkeeper/default.png"
   },
   "brooklyn": {
     "name": "Apache Brooklyn",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/brooklyn/default.png"
   },
   "brpc": {
     "name": "Apache bRPC",
-    "link": "https://github.com/apache/brpc/blob/master/THREAT_MODEL.md",
+    "security_model_link": "https://github.com/apache/brpc/blob/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/brpc/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://brpc.apache.org/docs/community/community/",
@@ -179,41 +208,48 @@
   },
   "buildstream": {
     "name": "Apache BuildStream",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@apache.org"
+    "contact": "security@apache.org",
+    "logo_link": null
   },
   "bval": {
     "name": "Apache BVal",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/bval/default.png"
   },
   "calcite": {
     "name": "Apache Calcite",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/calcite/default.png"
   },
   "camel": {
     "name": "Apache Camel",
-    "link": "https://camel.apache.org/manual/security-model.html",
+    "security_model_link": "https://camel.apache.org/manual/security-model.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/camel/default.png"
   },
   "carbondata": {
     "name": "Apache Carbondata",
-    "link": "https://carbondata.apache.org/security.html",
+    "security_model_link": "https://carbondata.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/carbondata/default.png"
   },
   "cassandra": {
     "name": "Apache Cassandra",
-    "link": "https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html",
+    "security_model_link": "https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://cassandra.apache.org/_/community.html#how-to-contribute",
@@ -221,35 +257,40 @@
   },
   "causeway": {
     "name": "Apache Causeway",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/causeway/default.png"
   },
   "cayenne": {
     "name": "Apache Cayenne",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/cayenne/default.png"
   },
   "celeborn": {
     "name": "Apache Celeborn",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/celeborn/default.png"
   },
   "celix": {
     "name": "Apache Celix",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/celix/default.png"
   },
   "cloudstack": {
     "name": "Apache CloudStack",
-    "link": "https://cloudstack.apache.org/security/",
+    "security_model_link": "https://cloudstack.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://cloudstack.apache.org/contribute",
@@ -257,146 +298,168 @@
   },
   "commons": {
     "name": "Apache Commons",
-    "link": "https://commons.apache.org/security.html",
+    "security_model_link": "https://commons.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://commons.apache.org/security.html#Known_Security_Vulnerabilities",
     "contact": "security@commons.apache.org",
     "logo_link": "https://www.apache.org/logos/res/commons/default.png"
   },
   "cordova": {
     "name": "Apache Cordova",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/cordova/default.png"
   },
   "couchdb": {
     "name": "Apache CouchDB",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@couchdb.apache.org",
     "logo_link": "https://www.apache.org/logos/res/couchdb/default.png"
   },
   "creadur": {
     "name": "Apache Creadur",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/creadur/default.png"
   },
   "ctakes": {
     "name": "Apache cTAKES",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/ctakes/default.png"
   },
   "curator": {
     "name": "Apache Curator",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/curator/default.png"
   },
   "cxf": {
     "name": "Apache CXF",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/cxf/default.png"
   },
   "daffodil": {
     "name": "Apache Daffodil",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/daffodil/default.png"
   },
   "datafu": {
     "name": "Apache DataFu",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/datafu/default.png"
   },
   "datafusion": {
     "name": "Apache DataFusion",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@apache.org"
+    "contact": "security@apache.org",
+    "logo_link": null
   },
   "datasketches": {
     "name": "Apache DataSketches",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/datasketches/default.png"
   },
   "db": {
     "name": "Apache DB",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/db/default.png"
   },
   "deltaspike": {
     "name": "Apache DeltaSpike",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/deltaspike/default.png"
   },
   "devlake": {
     "name": "Apache DevLake",
-    "link": "https://devlake.apache.org/docs/v1.0/GettingStarted/Authentication",
+    "security_model_link": "https://devlake.apache.org/docs/v1.0/GettingStarted/Authentication",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/devlake/default.png"
   },
   "directory": {
     "name": "Apache Directory",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/directory/default.png"
   },
   "dolphinscheduler": {
     "name": "Apache DolphinScheduler",
-    "link": "https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md",
+    "security_model_link": "https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/dolphinscheduler/dev/docs/docs/en/contribute/join/security.md",
     "advisory_link": null,
     "contact": "security@dolphinscheduler.apache.org",
     "logo_link": "https://www.apache.org/logos/res/dolphinscheduler/default.png"
   },
   "doris": {
     "name": "Apache Doris",
-    "link": "https://doris.apache.org/docs/dev/admin-manual/auth/security-overview",
+    "security_model_link": "https://doris.apache.org/docs/dev/admin-manual/auth/security-overview",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/doris/default.png"
   },
   "drill": {
     "name": "Apache Drill",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/drill/default.png"
   },
   "druid": {
     "name": "Apache Druid",
-    "link": "https://druid.apache.org/docs/latest/operations/security-overview.html",
+    "security_model_link": "https://druid.apache.org/docs/latest/operations/security-overview.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/druid/default.png"
   },
   "dubbo": {
     "name": "Apache Dubbo",
-    "link": "https://dubbo.apache.org/en/docs/notices/security/",
+    "security_model_link": "https://dubbo.apache.org/en/docs/notices/security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@dubbo.apache.org",
     "logo_link": "https://www.apache.org/logos/res/dubbo/default.png"
   },
   "echarts": {
     "name": "Apache ECharts",
-    "link": "https://echarts.apache.org/handbook/en/best-practices/security/#",
+    "security_model_link": "https://echarts.apache.org/handbook/en/best-practices/security/#",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://echarts.apache.org/en/contributing.html",
@@ -404,48 +467,56 @@
   },
   "empire-db": {
     "name": "Apache Empire-db",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@apache.org"
+    "contact": "security@apache.org",
+    "logo_link": null
   },
   "eventmesh": {
     "name": "Apache EventMesh",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/eventmesh/default.png"
   },
   "felix": {
     "name": "Apache Felix",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/felix/default.png"
   },
   "fineract": {
     "name": "Apache Fineract",
-    "link": "https://fineract.apache.org/security.html",
+    "security_model_link": "https://fineract.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://fineract.apache.org/security.html",
     "contact": "security@fineract.apache.org",
     "logo_link": "https://www.apache.org/logos/res/fineract/default.png"
   },
   "flagon": {
     "name": "Apache Flagon",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/flagon/default.png"
   },
   "flex": {
     "name": "Apache Flex",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/flex/default.png"
   },
   "flink": {
     "name": "Apache Flink",
-    "link": "https://flink.apache.org/what-is-flink/security/",
+    "security_model_link": "https://flink.apache.org/what-is-flink/security/",
+    "security_model_source": null,
     "advisory_link": "https://flink.apache.org/what-is-flink/security/",
     "contact": "security@apache.org",
     "contributing": "https://flink.apache.org/how-to-contribute/overview/",
@@ -453,62 +524,72 @@
   },
   "fory": {
     "name": "Apache Fory",
-    "link": "https://fory.apache.org/security/",
+    "security_model_link": "https://fory.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": "https://fory.apache.org/security/",
-    "contact": "security@apache.org"
+    "contact": "security@apache.org",
+    "logo_link": null
   },
   "freemarker": {
     "name": "Apache FreeMarker",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/freemarker/default.png"
   },
   "geode": {
     "name": "Apache Geode",
-    "link": "https://geode.apache.org/docs/guide/20/security/security_model.html",
+    "security_model_link": "https://geode.apache.org/docs/guide/20/security/security_model.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/geode/default.png"
   },
   "geronimo": {
     "name": "Apache Geronimo",
-    "link": "https://geronimo.apache.org/security-reports.html",
+    "security_model_link": "https://geronimo.apache.org/security-reports.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@geronimo.apache.org",
     "logo_link": "https://www.apache.org/logos/res/geronimo/default.png"
   },
   "gluten": {
     "name": "Apache Gluten",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/gluten/default.png"
   },
   "gobblin": {
     "name": "Apache Gobblin",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/gobblin/default.png"
   },
   "grails": {
     "name": "Apache Grails",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/grails/default.png"
   },
   "gravitino": {
     "name": "Apache Gravitino",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/gravitino/default.png"
   },
   "groovy": {
     "name": "Apache Groovy",
-    "link": "https://github.com/apache/groovy/blob/master/THREAT_MODEL.md",
+    "security_model_link": "https://github.com/apache/groovy/blob/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/groovy/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://groovy.apache.org/#contribute-btn",
@@ -516,28 +597,32 @@
   },
   "guacamole": {
     "name": "Apache Guacamole",
-    "link": "https://guacamole.apache.org/security/",
+    "security_model_link": "https://guacamole.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": "https://guacamole.apache.org/security/",
     "contact": "security@guacamole.apache.org",
     "logo_link": "https://www.apache.org/logos/res/guacamole/default.png"
   },
   "gump": {
     "name": "Apache Gump",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/gump/default.png"
   },
   "hadoop": {
     "name": "Apache Hadoop",
-    "link": "https://hadoop.apache.org/mailing_lists.html",
+    "security_model_link": "https://hadoop.apache.org/mailing_lists.html",
+    "security_model_source": null,
     "advisory_link": "https://hadoop.apache.org/cve_list.html",
     "contact": "security@hadoop.apache.org",
     "logo_link": "https://www.apache.org/logos/res/hadoop/default.png"
   },
   "hbase": {
     "name": "Apache HBase",
-    "link": "https://hbase.apache.org/security-model/",
+    "security_model_link": "https://hbase.apache.org/security-model/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://hbase.apache.org/#community",
@@ -545,14 +630,16 @@
   },
   "helix": {
     "name": "Apache Helix",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/helix/default.png"
   },
   "hertzbeat": {
     "name": "Apache Hertzbeat",
-    "link": "https://hertzbeat.apache.org/docs/help/security_model/",
+    "security_model_link": "https://hertzbeat.apache.org/docs/help/security_model/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://hertzbeat.apache.org/docs/community/contribution",
@@ -560,21 +647,24 @@
   },
   "hive": {
     "name": "Apache Hive",
-    "link": "https://hive.apache.org/mailing_lists.html",
+    "security_model_link": "https://hive.apache.org/mailing_lists.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@hive.apache.org",
     "logo_link": "https://www.apache.org/logos/res/hive/default.png"
   },
   "hop": {
     "name": "Apache Hop",
-    "link": "https://hop.apache.org/security/",
+    "security_model_link": "https://hop.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/hop/default.png"
   },
   "httpcomponents": {
     "name": "Apache HttpComponents",
-    "link": "https://hc.apache.org/security.html",
+    "security_model_link": "https://hc.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://hc.apache.org/get-involved.html",
@@ -582,7 +672,8 @@
   },
   "httpd": {
     "name": "Apache HTTP Server",
-    "link": "https://github.com/apache/httpd/blob/trunk/SECURITY.md",
+    "security_model_link": "https://github.com/apache/httpd/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/httpd/trunk/SECURITY.md",
     "advisory_link": "https://httpd.apache.org/security/vulnerabilities_24.html",
     "contact": "security@httpd.apache.org",
     "contributing": "https://httpd.apache.org/dev/",
@@ -590,21 +681,24 @@
   },
   "hudi": {
     "name": "Apache Hudi",
-    "link": "https://hudi.apache.org/contribute/security",
+    "security_model_link": "https://hudi.apache.org/contribute/security",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/hudi/default.png"
   },
   "hugegraph": {
     "name": "Apache HugeGraph",
-    "link": "https://hugegraph.apache.org/docs/guides/security",
+    "security_model_link": "https://hugegraph.apache.org/docs/guides/security",
+    "security_model_source": null,
     "advisory_link": "https://hugegraph.apache.org/docs/guides/security",
     "contact": "security@hugegraph.apache.org",
     "logo_link": "https://www.apache.org/logos/res/hugegraph/default.png"
   },
   "iceberg": {
     "name": "Apache Iceberg",
-    "link": "https://iceberg.apache.org/security/",
+    "security_model_link": "https://iceberg.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@iceberg.apache.org",
     "contributing": "https://iceberg.apache.org/community/",
@@ -612,7 +706,8 @@
   },
   "ignite": {
     "name": "Apache Ignite",
-    "link": "https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model",
+    "security_model_link": "https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@ignite.apache.org",
     "contributing": "https://ignite.apache.org/community/#contributing",
@@ -620,77 +715,88 @@
   },
   "impala": {
     "name": "Apache Impala",
-    "link": "https://github.com/apache/impala/blob/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/impala/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/impala/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/impala/default.png"
   },
   "inlong": {
     "name": "Apache InLong",
-    "link": "https://inlong.apache.org/docs/next/security/",
+    "security_model_link": "https://inlong.apache.org/docs/next/security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/inlong/default.png"
   },
   "iotdb": {
     "name": "Apache IoTDB",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/iotdb/default.png"
   },
   "jackrabbit": {
     "name": "Apache Jackrabbit",
-    "link": "https://jackrabbit.apache.org/jcr/security-reports.html",
+    "security_model_link": "https://jackrabbit.apache.org/jcr/security-reports.html",
+    "security_model_source": null,
     "advisory_link": "https://jackrabbit.apache.org/jcr/security-reports.html",
     "contact": "security@jackrabbit.apache.org",
     "logo_link": "https://www.apache.org/logos/res/jackrabbit/default.png"
   },
   "james": {
     "name": "Apache James",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/james/default.png"
   },
   "jena": {
     "name": "Apache Jena",
-    "link": "https://github.com/apache/jena/blob/main/THREAT_MODEL.md",
+    "security_model_link": "https://github.com/apache/jena/blob/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/jena/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/jena/default.png"
   },
   "jmeter": {
     "name": "Apache JMeter",
-    "link": "https://jmeter.apache.org/security.html",
+    "security_model_link": "https://jmeter.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/jmeter/default.png"
   },
   "johnzon": {
     "name": "Apache Johnzon",
-    "link": "https://johnzon.apache.org/security.html",
+    "security_model_link": "https://johnzon.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/johnzon/default.png"
   },
   "jspwiki": {
     "name": "Apache JSPWiki",
-    "link": "https://jspwiki-wiki.apache.org/Wiki.jsp?page=Security",
+    "security_model_link": "https://jspwiki-wiki.apache.org/Wiki.jsp?page=Security",
+    "security_model_source": null,
     "advisory_link": "https://jspwiki-wiki.apache.org/Wiki.jsp?page=CVE",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/jspwiki/default.png"
   },
   "juneau": {
     "name": "Apache Juneau",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/juneau/default.png"
   },
   "kafka": {
     "name": "Apache Kafka",
-    "link": "https://kafka.apache.org/project-security.html",
+    "security_model_link": "https://kafka.apache.org/project-security.html",
+    "security_model_source": null,
     "advisory_link": "https://kafka.apache.org/cve-list.html",
     "contact": "security@kafka.apache.org",
     "dependency_advisory_triage": "https://github.com/apache/kafka/blob/trunk/gradle/resources/dependencycheck-suppressions.xml",
@@ -698,42 +804,48 @@
   },
   "karaf": {
     "name": "Apache Karaf",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/karaf/default.png"
   },
   "knox": {
     "name": "Apache Knox",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/knox/default.png"
   },
   "kudu": {
     "name": "Apache Kudu",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/kudu/default.png"
   },
   "kvrocks": {
     "name": "Apache Kvrocks",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/kvrocks/default.png"
   },
   "kylin": {
     "name": "Apache Kylin",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/kylin/default.png"
   },
   "kyuubi": {
     "name": "Apache Kyuubi",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@kyuubi.apache.org",
     "contributing": "https://kyuubi.apache.org/mailing_lists.html",
@@ -741,76 +853,88 @@
   },
   "libcloud": {
     "name": "Apache Libcloud",
-    "link": "https://libcloud.apache.org/security.html",
+    "security_model_link": "https://libcloud.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@libcloud.apache.org",
     "logo_link": "https://www.apache.org/logos/res/libcloud/default.png"
   },
   "linkis": {
     "name": "Apache Linkis",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/linkis/default.png"
   },
   "livy": {
     "name": "Apache Livy",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/livy/default.png"
   },
   "logging": {
     "name": "Apache Logging",
-    "link": "https://logging.apache.org/security.html",
+    "security_model_link": "https://logging.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://logging.apache.org/security.html",
-    "contact": "security@logging.apache.org"
+    "contact": "security@logging.apache.org",
+    "logo_link": null
   },
   "lucene": {
     "name": "Apache Lucene",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@lucene.apache.org",
     "logo_link": "https://www.apache.org/logos/res/lucene/default.png"
   },
   "lucenenet": {
     "name": "Apache Lucene.NET",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/lucenenet/default.png"
   },
   "madlib": {
     "name": "Apache MADlib",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/madlib/default.png"
   },
   "magpie": {
     "name": "Apache Magpie",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/magpie/default.png"
   },
   "mahout": {
     "name": "Apache Mahout",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/mahout/default.png"
   },
   "manifoldcf": {
     "name": "Apache ManifoldCF",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/manifoldcf/default.png"
   },
   "maven": {
     "name": "Apache Maven",
-    "link": "https://maven.apache.org/security.html",
+    "security_model_link": "https://maven.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://maven.apache.org/developers/index.html",
@@ -818,125 +942,144 @@
   },
   "metron": {
     "name": "Apache Metron",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@metron.apache.org"
+    "contact": "security@metron.apache.org",
+    "logo_link": null
   },
   "mina": {
     "name": "Apache MINA",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/mina/default.png"
   },
   "myfaces": {
     "name": "Apache MyFaces",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/myfaces/default.png"
   },
   "mynewt": {
     "name": "Apache Mynewt",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/mynewt/default.png"
   },
   "netbeans": {
     "name": "Apache NetBeans",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/netbeans/default.png"
   },
   "nifi": {
     "name": "Apache NiFi",
-    "link": "https://nifi.apache.org/documentation/security/",
+    "security_model_link": "https://nifi.apache.org/documentation/security/",
+    "security_model_source": null,
     "advisory_link": "https://nifi.apache.org/documentation/security/",
     "contact": "security@nifi.apache.org",
     "logo_link": "https://www.apache.org/logos/res/nifi/default.png"
   },
   "nutch": {
     "name": "Apache Nutch",
-    "link": "https://nutch.apache.org/documentation/security/#security-model",
+    "security_model_link": "https://nutch.apache.org/documentation/security/#security-model",
+    "security_model_source": null,
     "advisory_link": "https://nutch.apache.org/documentation/security/#nutch-cve-list",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/nutch/default.png"
   },
   "nuttx": {
     "name": "Apache NuttX",
-    "link": "https://nuttx.apache.org/docs/latest/security.html",
+    "security_model_link": "https://nuttx.apache.org/docs/latest/security.html",
+    "security_model_source": null,
     "advisory_link": "https://nuttx.apache.org/docs/latest/security.html#nuttx-cves",
     "contact": "security@nuttx.apache.org",
     "logo_link": "https://www.apache.org/logos/res/nuttx/default.png"
   },
   "ofbiz": {
     "name": "Apache OFBiz",
-    "link": "https://ofbiz.apache.org/security.html",
+    "security_model_link": "https://ofbiz.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://ofbiz.apache.org/security.html",
     "contact": "security@ofbiz.apache.org",
     "logo_link": "https://www.apache.org/logos/res/ofbiz/default.png"
   },
   "opendal": {
     "name": "Apache OpenDAL",
-    "link": "https://github.com/apache/opendal/blob/main/SECURITY-THREAT-MODEL.md",
+    "security_model_link": "https://github.com/apache/opendal/blob/main/SECURITY-THREAT-MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/opendal/main/SECURITY-THREAT-MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/opendal/default.png"
   },
   "openjpa": {
     "name": "Apache OpenJPA",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/openjpa/default.png"
   },
   "openmeetings": {
     "name": "Apache OpenMeetings",
-    "link": "https://openmeetings.apache.org/security.html",
+    "security_model_link": "https://openmeetings.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@openmeetings.apache.org",
     "logo_link": "https://www.apache.org/logos/res/openmeetings/default.png"
   },
   "opennlp": {
     "name": "Apache OpenNLP",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/opennlp/default.png"
   },
   "openoffice": {
     "name": "Apache OpenOffice",
-    "link": "https://openoffice.apache.org/security",
+    "security_model_link": "https://openoffice.apache.org/security",
+    "security_model_source": null,
     "advisory_link": "https://www.openoffice.org/security/bulletin.html",
     "contact": "security@openoffice.apache.org",
     "logo_link": "https://www.apache.org/logos/res/openoffice/default.png"
   },
   "openwebbeans": {
     "name": "Apache OpenWebBeans",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/openwebbeans/default.png"
   },
   "openwhisk": {
     "name": "Apache OpenWhisk",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/openwhisk/default.png"
   },
   "orc": {
     "name": "Apache ORC",
-    "link": "https://orc.apache.org/security/",
+    "security_model_link": "https://orc.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": "https://orc.apache.org/security/",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/orc/default.png"
   },
   "ozone": {
     "name": "Apache Ozone",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@ozone.apache.org",
     "contributing": "https://ozone.apache.org/community/how-to-contribute",
@@ -944,84 +1087,96 @@
   },
   "paimon": {
     "name": "Apache Paimon",
-    "link": "https://github.com/apache/paimon/blob/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/paimon/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/paimon/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/paimon/default.png"
   },
   "parquet": {
     "name": "Apache Parquet",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/parquet/default.png"
   },
   "pdfbox": {
     "name": "Apache PDFBox",
-    "link": "https://pdfbox.apache.org/security.html",
+    "security_model_link": "https://pdfbox.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/pdfbox/default.png"
   },
   "pekko": {
     "name": "Apache Pekko",
-    "link": "https://pekko.apache.org/docs/pekko/current/security/index.html",
+    "security_model_link": "https://pekko.apache.org/docs/pekko/current/security/index.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/pekko/default.png"
   },
   "perl": {
     "name": "Apache mod_perl",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/perl/default.png"
   },
   "phoenix": {
     "name": "Apache Phoenix",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/phoenix/default.png"
   },
   "pig": {
     "name": "Apache Pig",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/pig/default.png"
   },
   "pinot": {
     "name": "Apache Pinot",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/pinot/default.png"
   },
   "plc4x": {
     "name": "Apache PLC4X",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/plc4x/default.png"
   },
   "poi": {
     "name": "Apache POI",
-    "link": "https://poi.apache.org/security.html",
+    "security_model_link": "https://poi.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/poi/default.png"
   },
   "polaris": {
     "name": "Apache Polaris",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/polaris/default.png"
   },
   "pulsar": {
     "name": "Apache Pulsar",
-    "link": "https://github.com/apache/pulsar/security/policy",
+    "security_model_link": "https://github.com/apache/pulsar/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/pulsar/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://pulsar.apache.org/community/#section-contribute",
@@ -1029,14 +1184,16 @@
   },
   "qpid": {
     "name": "Apache Qpid",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/qpid/default.png"
   },
   "ranger": {
     "name": "Apache Ranger",
-    "link": "https://cwiki.apache.org/confluence/display/RANGER/Lock+down+Apache+Ranger+for+production+deployments",
+    "security_model_link": "https://cwiki.apache.org/confluence/display/RANGER/Lock+down+Apache+Ranger+for+production+deployments",
+    "security_model_source": null,
     "advisory_link": "https://cwiki.apache.org/confluence/display/RANGER/Vulnerabilities+found+in+Ranger",
     "contact": "security@apache.org",
     "contributing": "https://rocketmq.apache.org/docs/contributionGuide/01how-to-contribute",
@@ -1044,14 +1201,16 @@
   },
   "ratis": {
     "name": "Apache Ratis",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/ratis/default.png"
   },
   "rocketmq": {
     "name": "Apache RocketMQ",
-    "link": "https://rocketmq.apache.org/docs/security/01security/",
+    "security_model_link": "https://rocketmq.apache.org/docs/security/01security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://rocketmq.apache.org/docs/contributionGuide/01how-to-contribute",
@@ -1059,56 +1218,64 @@
   },
   "roller": {
     "name": "Apache Roller",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/roller/default.png"
   },
   "royale": {
     "name": "Apache Royale",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/royale/default.png"
   },
   "rya": {
     "name": "Apache Rya",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/rya/default.png"
   },
   "samza": {
     "name": "Apache Samza",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/samza/default.png"
   },
   "santuario": {
     "name": "Apache Santuario",
-    "link": "https://santuario.apache.org/secadv.html",
+    "security_model_link": "https://santuario.apache.org/secadv.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/santuario/default.png"
   },
   "sdap": {
     "name": "Apache SDAP",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/sdap/default.png"
   },
   "seata": {
     "name": "Apache Seata",
-    "link": "https://seata.apache.org/docs/next/security/secret-key",
+    "security_model_link": "https://seata.apache.org/docs/next/security/secret-key",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/seata/default.png"
   },
   "seatunnel": {
     "name": "Apache SeaTunnel",
-    "link": "https://seatunnel.apache.org/security",
+    "security_model_link": "https://seatunnel.apache.org/security",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://seatunnel.apache.org/community/contribution_guide/contribute",
@@ -1116,34 +1283,40 @@
   },
   "sedona": {
     "name": "Apache Sedona",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/sedona/default.png"
   },
   "sentry": {
     "name": "Apache Sentry",
-    "link": "https://cwiki.apache.org/confluence/display/SENTRY/Vulnerabilities+found+in+Apache+Sentry",
+    "security_model_link": "https://cwiki.apache.org/confluence/display/SENTRY/Vulnerabilities+found+in+Apache+Sentry",
+    "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@sentry.apache.org"
+    "contact": "security@sentry.apache.org",
+    "logo_link": null
   },
   "serf": {
     "name": "Apache Serf",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/serf/default.png"
   },
   "servicecomb": {
     "name": "Apache ServiceComb",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/servicecomb/default.png"
   },
   "shardingsphere": {
     "name": "Apache ShardingSphere",
-    "link": "https://shardingsphere.apache.org/community/en/security/",
+    "security_model_link": "https://shardingsphere.apache.org/community/en/security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://shardingsphere.apache.org/community/en/involved/",
@@ -1151,14 +1324,16 @@
   },
   "shenyu": {
     "name": "Apache ShenYu",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/shenyu/default.png"
   },
   "shiro": {
     "name": "Apache Shiro",
-    "link": "https://shiro.apache.org/security-reports.html",
+    "security_model_link": "https://shiro.apache.org/security-reports.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@shiro.apache.org",
     "contributing": "https://github.com/apache/shiro/blob/main/CONTRIBUTING.md",
@@ -1166,35 +1341,40 @@
   },
   "singa": {
     "name": "Apache SINGA",
-    "link": "https://singa.apache.org/security.html",
+    "security_model_link": "https://singa.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@singa.apache.org",
     "logo_link": "https://www.apache.org/logos/res/singa/default.png"
   },
   "sis": {
     "name": "Apache SIS",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/sis/default.png"
   },
   "skywalking": {
     "name": "Apache SkyWalking",
-    "link": "https://skywalking.apache.org/docs/main/next/en/security/readme/",
+    "security_model_link": "https://skywalking.apache.org/docs/main/next/en/security/readme/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/skywalking/default.png"
   },
   "sling": {
     "name": "Apache Sling",
-    "link": "https://sling.apache.org/project-information/security.html",
+    "security_model_link": "https://sling.apache.org/project-information/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@sling.apache.org",
     "logo_link": "https://www.apache.org/logos/res/sling/default.png"
   },
   "solr": {
     "name": "Apache Solr",
-    "link": "https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity",
+    "security_model_link": "https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity",
+    "security_model_source": null,
     "advisory_link": "https://solr.apache.org/security.html#recent-cve-reports-for-apache-solr",
     "contact": "security@solr.apache.org",
     "dependency_advisory_triage": "https://solr.apache.org/solr.vex.json",
@@ -1202,14 +1382,16 @@
   },
   "spamassassin": {
     "name": "Apache SpamAssassin",
-    "link": "https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy",
+    "security_model_link": "https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@spamassassin.apache.org",
     "logo_link": "https://www.apache.org/logos/res/spamassassin/default.png"
   },
   "spark": {
     "name": "Apache Spark",
-    "link": "https://spark.apache.org/security.html",
+    "security_model_link": "https://spark.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://spark.apache.org/security.html",
     "contact": "security@apache.org",
     "contributing": "https://spark.apache.org/contributing.html",
@@ -1217,131 +1399,152 @@
   },
   "steve": {
     "name": "Apache Steve",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/steve/default.png"
   },
   "storm": {
     "name": "Apache Storm",
-    "link": "https://storm.apache.org/security-model.html",
+    "security_model_link": "https://storm.apache.org/security-model.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/storm/default.png"
   },
   "stormcrawler": {
     "name": "Apache StormCrawler",
-    "link": "https://stormcrawler.apache.org/security/",
+    "security_model_link": "https://stormcrawler.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": "https://stormcrawler.apache.org/security/",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/stormcrawler/default.png"
   },
   "streampark": {
     "name": "Apache StreamPark",
-    "link": "https://streampark.apache.org/community/security/",
+    "security_model_link": "https://streampark.apache.org/community/security/",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/streampark/default.png"
   },
   "streampipes": {
     "name": "Apache StreamPipes",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/streampipes/default.png"
   },
   "struts": {
     "name": "Apache Struts",
-    "link": "https://struts.apache.org/security.html",
+    "security_model_link": "https://struts.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://cwiki.apache.org/confluence/display/WW/Security+Bulletins",
     "contact": "security@struts.apache.org",
     "logo_link": "https://www.apache.org/logos/res/struts/default.png"
   },
   "subversion": {
     "name": "Apache Subversion",
-    "link": "https://subversion.apache.org/security/",
+    "security_model_link": "https://subversion.apache.org/security/",
+    "security_model_source": null,
     "advisory_link": "https://subversion.apache.org/security/",
     "contact": "security@subversion.apache.org",
     "logo_link": "https://www.apache.org/logos/res/subversion/default.png"
   },
   "superset": {
     "name": "Apache Superset",
-    "link": "https://github.com/apache/superset/blob/master/.github/SECURITY.md",
+    "security_model_link": "https://github.com/apache/superset/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/superset/master/SECURITY.md",
     "advisory_link": "https://superset.apache.org/docs/security/cves",
     "contact": "security@superset.apache.org",
     "logo_link": "https://www.apache.org/logos/res/superset/default.png"
   },
   "synapse": {
     "name": "Apache Synapse",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/synapse/default.png"
   },
   "syncope": {
     "name": "Apache Syncope",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": "https://syncope.apache.org/security",
+    "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/syncope/default.png"
   },
   "systemds": {
     "name": "Apache SystemDS",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@apache.org"
+    "contact": "security@apache.org",
+    "logo_link": null
   },
   "tapestry": {
     "name": "Apache Tapestry",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tapestry/default.png"
   },
   "tcl": {
     "name": "Apache Tcl",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tcl/default.png"
   },
   "teaclave": {
     "name": "Apache Teaclave",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/teaclave/default.png"
   },
   "tez": {
     "name": "Apache Tez",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tez/default.png"
   },
   "thrift": {
     "name": "Apache Thrift",
-    "link": "https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md",
+    "security_model_link": "https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/thrift/master/doc/thrift-threat-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/thrift/default.png"
   },
   "tika": {
     "name": "Apache Tika",
-    "link": "https://tika.apache.org/security-model.html",
+    "security_model_link": "https://tika.apache.org/security-model.html",
+    "security_model_source": null,
     "advisory_link": "https://tika.apache.org/security.html",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tika/default.png"
   },
   "tinkerpop": {
     "name": "Apache TinkerPop",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tinkerpop/default.png"
   },
   "tomcat": {
     "name": "Apache Tomcat",
-    "link": "https://tomcat.apache.org/security.html",
+    "security_model_link": "https://tomcat.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": "https://tomcat.apache.org/security.html",
     "contact": "security@tomcat.apache.org",
     "contributing": "https://tomcat.apache.org/getinvolved.html",
@@ -1349,167 +1552,192 @@
   },
   "tomee": {
     "name": "Apache TomEE",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tomee/default.png"
   },
   "trafficcontrol": {
     "name": "Apache Traffic Control",
-    "link": "https://trafficcontrol.apache.org/security/index.html",
+    "security_model_link": "https://trafficcontrol.apache.org/security/index.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@trafficcontrol.apache.org",
     "logo_link": "https://www.apache.org/logos/res/trafficcontrol/default.png"
   },
   "trafficserver": {
     "name": "Apache Traffic Server",
-    "link": "https://github.com/apache/trafficserver/security/policy",
+    "security_model_link": "https://github.com/apache/trafficserver/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@trafficserver.apache.org",
     "logo_link": "https://www.apache.org/logos/res/trafficserver/default.png"
   },
   "trafodion": {
     "name": "Apache Trafodion",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@trafodion.apache.org"
+    "contact": "security@trafodion.apache.org",
+    "logo_link": null
   },
   "training": {
     "name": "Apache Training",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/training/default.png"
   },
   "tsfile": {
     "name": "Apache TsFile",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tsfile/default.png"
   },
   "turbine": {
     "name": "Apache Turbine",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/turbine/default.png"
   },
   "tvm": {
     "name": "Apache TVM",
-    "link": "https://tvm.apache.org/docs/reference/security.html",
+    "security_model_link": "https://tvm.apache.org/docs/reference/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tvm/default.png"
   },
   "uima": {
     "name": "Apache UIMA",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/uima/default.png"
   },
   "uniffle": {
     "name": "Apache Uniffle",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/uniffle/default.png"
   },
   "unomi": {
     "name": "Apache Unomi",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/unomi/default.png"
   },
   "vcl": {
     "name": "Apache VCL",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/vcl/default.png"
   },
   "velocity": {
     "name": "Apache Velocity",
-    "link": "https://velocity.apache.org/#security-model",
+    "security_model_link": "https://velocity.apache.org/#security-model",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/velocity/default.png"
   },
   "wayang": {
     "name": "Apache Wayang",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/wayang/default.png"
   },
   "whimsy": {
     "name": "Apache Whimsy",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/whimsy/default.png"
   },
   "wicket": {
     "name": "Apache Wicket",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/wicket/default.png"
   },
   "ws": {
     "name": "Apache Web Services",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/ws/default.png"
   },
   "xalan": {
     "name": "Apache Xalan",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/xalan/default.png"
   },
   "xerces": {
     "name": "Apache Xerces",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/xerces/default.png"
   },
   "xmlgraphics": {
     "name": "Apache XML Graphics",
-    "link": "https://xmlgraphics.apache.org/security.html",
+    "security_model_link": "https://xmlgraphics.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/xmlgraphics/default.png"
   },
   "yetus": {
     "name": "Apache Yetus",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/yetus/default.png"
   },
   "yunikorn": {
     "name": "Apache YuniKorn",
-    "link": null,
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/yunikorn/default.png"
   },
   "zeppelin": {
     "name": "Apache Zeppelin",
-    "link": "https://zeppelin.apache.org/security.html",
+    "security_model_link": "https://zeppelin.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@zeppelin.apache.org",
     "logo_link": "https://www.apache.org/logos/res/zeppelin/default.png"
   },
   "zookeeper": {
     "name": "Apache ZooKeeper",
-    "link": "https://zookeeper.apache.org/security.html",
+    "security_model_link": "https://zookeeper.apache.org/security.html",
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@zookeeper.apache.org",
     "logo_link": "https://www.apache.org/logos/res/zookeeper/default.png"

--- a/scripts/project-coordinates.schema.json
+++ b/scripts/project-coordinates.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://security.apache.org/schemas/project-coordinates.schema.json",
+  "title": "Apache project security coordinates",
+  "description": "Hand-maintained security coordinates for Apache projects, keyed by PMC/committee id. Consumed by scripts/project-page.py to build the projects overview and by external tools.",
+  "type": "object",
+  "propertyNames": {
+    "pattern": "^(\\$schema|[a-z0-9][a-z0-9-]*)$"
+  },
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional reference to this schema so editors validate the file. Ignored by the site generator (keys starting with '$' are not treated as projects)."
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/$defs/project"
+  },
+  "$defs": {
+    "urlOrNull": {
+      "type": ["string", "null"],
+      "format": "uri"
+    },
+    "project": {
+      "type": "object",
+      "description": "Security coordinates for a single project. The six core fields are always present (null when unknown) so consumers need no per-field presence checks.",
+      "required": [
+        "name",
+        "security_model_link",
+        "security_model_source",
+        "advisory_link",
+        "contact",
+        "logo_link"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable project name, e.g. \"Apache Kafka\"."
+        },
+        "security_model_link": {
+          "$ref": "#/$defs/urlOrNull",
+          "description": "URL of the project's human-facing (HTML) security page or threat model, shown on the site. Null when the project has none."
+        },
+        "security_model_source": {
+          "$ref": "#/$defs/urlOrNull",
+          "description": "URL of an AI-friendly plain-text/Markdown version of the security page. Not rendered on the site; used by external tooling to fetch text instead of HTML. Null when unavailable."
+        },
+        "advisory_link": {
+          "$ref": "#/$defs/urlOrNull",
+          "description": "URL of the project's published list of security advisories. Null when the project has none."
+        },
+        "contact": {
+          "type": "string",
+          "format": "email",
+          "minLength": 1,
+          "description": "Security reporting address. Defaults to security@apache.org when the project has no dedicated list."
+        },
+        "logo_link": {
+          "$ref": "#/$defs/urlOrNull",
+          "description": "URL of the project logo shown next to its name. Null when no logo is available."
+        },
+        "contributing": {
+          "$ref": "#/$defs/urlOrNull",
+          "description": "Optional URL of the project's contributing guide."
+        },
+        "dependency_advisory_triage": {
+          "$ref": "#/$defs/urlOrNull",
+          "description": "Optional URL of the project's dependency-advisory triage data (e.g. VEX or suppression file)."
+        }
+      }
+    }
+  }
+}

--- a/scripts/project-page.py
+++ b/scripts/project-page.py
@@ -12,7 +12,8 @@ from urllib.parse import urlparse, quote
 
 # manually maintained
 with open('project-coordinates.json', 'r') as p:
-    project_coordinates = json.load(p)
+    # Drop editor-only meta keys (e.g. "$schema"); every remaining key is a project.
+    project_coordinates = {k: v for k, v in json.load(p).items() if not k.startswith('$')}
 
 # fetched from https://projects.apache.org/json/foundation/committees.json
 with open('committees.json', 'r') as cs:
@@ -131,9 +132,9 @@ def project_md_lines(pmc, p):
             lines.append('    [security.apache.org](/projects/%s/)' % pmc)
         else:
             lines.append('    none so far')
-    if p.get('link'):
+    if p.get('security_model_link'):
         lines.append('  - Security page:\\')
-        lines.append('    [%s](%s)' % (urlparse(p['link']).netloc or 'security page', p['link']))
+        lines.append('    [%s](%s)' % (urlparse(p['security_model_link']).netloc or 'security page', p['security_model_link']))
     return lines
 
 # Group projects by their initial letter (non-letters bucket under '#').
@@ -198,8 +199,8 @@ layout: single
 """ % (p['name'], p['name']))
     project_page.write('# Reporting\n\n')
     project_page.write('Do you want disclose a potential security issue for %s? ' % p['name'])
-    if 'link' in p.keys() and p['link']:
-        project_page.write("You can read more about the projects' security policy on their [security page](%s), and email your report to the " % p['link'])
+    if 'security_model_link' in p.keys() and p['security_model_link']:
+        project_page.write("You can read more about the projects' security policy on their [security page](%s), and email your report to the " % p['security_model_link'])
     else:
         project_page.write('Send your report to the ')
     if not 'contact' in p.keys() or p['contact'] == 'security@apache.org':
@@ -211,8 +212,8 @@ layout: single
 
     project_page.write('\n\nThis section is experimental: it provides advisories since 2023 and ')
     project_page.write('may lag behind the official CVE publications. ')
-    if 'link' in p.keys() and p['link']:
-        project_page.write('It may also lack details found on the [project security page](%s). ' % p['link'])
+    if 'security_model_link' in p.keys() and p['security_model_link']:
+        project_page.write('It may also lack details found on the [project security page](%s). ' % p['security_model_link'])
 
     project_page.write('If you have any feedback on how you would like this data to be provided, ')
     project_page.write('you are welcome to reach out on our public [mailinglist](/mailinglist) or privately ')


### PR DESCRIPTION
Renames the `link` field in `scripts/project-coordinates.json` to `security_model_link`, and adds a `security_model_source` field pointing at an AI-friendly plain-text (raw GitHub) version of each security page. The source is not rendered on the site; it is there for external tooling that prefers text over HTML.

## Changes
- Add `scripts/project-coordinates.schema.json` (JSON Schema; the six core fields are required) and reference it from the data file via a `$schema` key. The page generator and the DOAP cross-check now skip `$`-prefixed meta keys.
- Normalize every entry to carry the six core fields (null when absent); default the one missing `contact` to `security@apache.org`.
- Fill `security_model_source` from `raw.githubusercontent.com` for GitHub-hosted security pages.
- Normalize GitHub `SECURITY.md` entries to the canonical `/security/policy` human link, with the raw `SECURITY.md` as the source. Entries pointing at other files (THREAT_MODEL.md, *.adoc, deep paths) keep their blob link+source.
- Regenerate the affected overview and project pages (activemq, httpd, impala, superset security-page links).

## Verification
- All 214 entries validate against the new schema; IDE reports no diagnostics.
- Every GitHub link and source URL was checked and returns HTTP 200.
- Scripts `py_compile` clean; the generator was re-run to produce the page changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)