### PR TITLE
Add SBOMs for more Ant products

### DIFF
--- a/sboms/README.md
+++ b/sboms/README.md
@@ -16,6 +16,9 @@ Apache Software Foundation produced SBOMs
 ### CycloneDX Antlib
 - 0.1: [1 SBOM](ant/ant-cyclonedx-0.1.md)
 
+### Ivy
+- 2.6.0: [1 SBOM](ant/ivy-2.6.0.md)
+
 ### Props Antlib
 - 1.0.0: [1 SBOM](ant/ant-props-1.0.0.md)
 

--- a/sboms/README.md
+++ b/sboms/README.md
@@ -10,6 +10,10 @@ Apache Software Foundation produced SBOMs
 - 2.10.2: [21 SBOMs](airflow/airflow-2.10.2.md)
 
 ## Ant
+### AntUnit
+- 1.5.0: [1 SBOM](ant/ant-antunit-1.5.0.md)
+
+### CycloneDX Antlib
 - 0.1: [1 SBOM](ant/ant-cyclonedx-0.1.md)
 
 ## Arrow

--- a/sboms/README.md
+++ b/sboms/README.md
@@ -16,6 +16,9 @@ Apache Software Foundation produced SBOMs
 ### CycloneDX Antlib
 - 0.1: [1 SBOM](ant/ant-cyclonedx-0.1.md)
 
+### Props Antlib
+- 1.0.0: [1 SBOM](ant/ant-props-1.0.0.md)
+
 ## Arrow
 - 11.0.0: [1 SBOM](arrow/arrow-11.0.0.md)
 - 15.0.2: [1 SBOM](arrow/arrow-15.0.2.md)

--- a/sboms/ant/ant-antunit-1.5.0.md
+++ b/sboms/ant/ant-antunit-1.5.0.md
@@ -1,0 +1,6 @@
+AntUnit 1.5.0: 1 SBOM
+=======
+
+| file, spec<br>Serial Number, version| metadata | components<br>by type<br>- libs purl types |
+| ----------------------------------- | -------- | ------------------------------------------ |
+| **[ant-antunit-1.5.0-cyclonedx](maven/org.apache.ant/ant-antunit/1.5.0/ant-antunit-1.5.0-cyclonedx.json)**<br>json CycloneDX 1.6<br>urn:uuid:7bd88151-8615-4d21-980b-8290be5d047b<br>version: 1 | **maven/org.apache.ant/ant-antunit@1.5.0?type=jar**<br>type: LIBRARY<br>timestamp: 2026-06-14 14:53:28<br>tool: ant-cyclonedx 0.1 | 4<br>`library`: 4 <br>- `maven`: 4  |

--- a/sboms/ant/ant-props-1.0.0.md
+++ b/sboms/ant/ant-props-1.0.0.md
@@ -1,0 +1,6 @@
+Props Antlib 1.0.0: 1 SBOM
+=======
+
+| file, spec<br>Serial Number, version| metadata | components<br>by type<br>- libs purl types |
+| ----------------------------------- | -------- | ------------------------------------------ |
+| **[ant-props-1.0.0.cdx](maven/org.apache.ant/ant-props/1.0.0/ant-props-1.0.0.cdx.json)**<br>json CycloneDX 1.6<br>urn:uuid:df44e38d-d103-4dcc-b918-036ca12e6998<br>version: 1 | **maven/org.apache.ant/ant-props@1.0.0?type=jar**<br>type: LIBRARY<br>timestamp: 2026-06-20 10:20:17<br>tool: ant-cyclonedx 0.1 | 2<br>`library`: 2 <br>- `maven`: 2  |

--- a/sboms/ant/ivy-2.6.0.md
+++ b/sboms/ant/ivy-2.6.0.md
@@ -1,0 +1,6 @@
+Ivy 2.6.0: 1 SBOM
+=======
+
+| file, spec<br>Serial Number, version| metadata | components<br>by type<br>- libs purl types |
+| ----------------------------------- | -------- | ------------------------------------------ |
+| **[ivy-2.6.0.cdx](maven/org.apache.ivy/ivy/2.6.0/ivy-2.6.0.cdx.json)**<br>json CycloneDX 1.6<br>urn:uuid:21c5673c-68b4-475e-a6e7-19255f932b17<br>version: 1 | **maven/org.apache.ivy/ivy@2.6.0?type=jar**<br>type: LIBRARY<br>timestamp: 2026-07-12 08:01:38<br>tool: ant-cyclonedx 0.1 | 14<br>`library`: 14 <br>- `maven`: 14  |

--- a/sboms/ant/maven/org.apache.ant/ant-antunit/1.5.0/ant-antunit-1.5.0-cyclonedx.json
+++ b/sboms/ant/maven/org.apache.ant/ant-antunit/1.5.0/ant-antunit-1.5.0-cyclonedx.json
@@ -1,0 +1,477 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:7bd88151-8615-4d21-980b-8290be5d047b",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2026-06-14T12:53:28Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : {
+      "components" : [
+        {
+          "type" : "library",
+          "supplier" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "manufacturer" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "publisher" : "The Apache Software Foundation",
+          "group" : "org.apache.ant",
+          "name" : "ant-cyclonedx",
+          "version" : "0.1",
+          "description" : "Apache CycloneDX Antlib",
+          "hashes" : [
+            {
+              "alg" : "MD5",
+              "content" : "f00bf8afd0fd1a4677a80aa400934230"
+            },
+            {
+              "alg" : "SHA-1",
+              "content" : "64676be7248fc2ec0eef936be9c2507909e05414"
+            },
+            {
+              "alg" : "SHA-256",
+              "content" : "a4f295746ba0ea50d7b720dc4f42ffbe5a98bc3ad9f0d175a0be80a5bd108e84"
+            },
+            {
+              "alg" : "SHA-512",
+              "content" : "b0fa0bc41af224339d3bd301fe308de3bd3b0f75ad7ded60559469fa4eed85bec96e0eb195ae1db14fad2a8aaed42c776b3268575d7feeac6751a7737193cf3c"
+            },
+            {
+              "alg" : "SHA3-256",
+              "content" : "8af81f7d1cda4165dd841ef06ef5fa928a103a2de487bc62e659f98618c6f8d7"
+            },
+            {
+              "alg" : "SHA3-512",
+              "content" : "5584260043593ad9abcd6b2c9630edc65422f6b4853cc884935d995d9f4a04c6be6ad4504a38f16910fbff698f5411cbe5bbab0ee071f6011eeef51a9fa93cdb"
+            },
+            {
+              "alg" : "SHA-384",
+              "content" : "3532c340f51512b3521f96fe1f96b49cb7748c2b117ca4670dad26db8842efced5a64a366af01be2a25940eac63acf3f"
+            },
+            {
+              "alg" : "SHA3-384",
+              "content" : "64b575e8e4c5f28d77fa55aa81f031c7fa7873ccda1ab3f4429e35587c3d33cc1f66bcb9e3caae1c0945f24ab722362c"
+            }
+          ],
+          "licenses" : [
+            {
+              "license" : {
+                "id" : "Apache-2.0",
+                "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+              }
+            }
+          ],
+          "purl" : "pkg:maven/org.apache.ant/ant-cyclonedx@0.1?type=jar",
+          "externalReferences" : [
+            {
+              "type" : "vcs",
+              "url" : "https://gitbox.apache.org/repos/asf/ant-antlibs-cyclonedx.git"
+            },
+            {
+              "type" : "license",
+              "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            },
+            {
+              "type" : "build-system",
+              "url" : "https://ci-builds.apache.org/job/Ant/job/CycloneDX%20Antlib/"
+            },
+            {
+              "type" : "mailing-list",
+              "url" : "https://ant.apache.org/mail.html"
+            },
+            {
+              "type" : "issue-tracker",
+              "url" : "https://bz.apache.org/bugzilla/buglist.cgi?component=CycloneDX%20Antlib&product=Ant"
+            },
+            {
+              "type" : "website",
+              "url" : "https://ant.apache.org/antlibs/cyclonedx/"
+            },
+            {
+              "type" : "distribution",
+              "url" : "https://ant.apache.org/antlibs/bindownload.cgi"
+            },
+            {
+              "type" : "source-distribution",
+              "url" : "https://ant.apache.org/antlibs/srcdownload.cgi"
+            },
+            {
+              "type" : "security-contact",
+              "url" : "https://www.apache.org/security/"
+            }
+          ]
+        }
+      ]
+    },
+    "component" : {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant-antunit@1.5.0?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "manufacturer" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.ant",
+      "name" : "ant-antunit",
+      "version" : "1.5.0",
+      "description" : "Apache AntUnit",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9ad7ac20677ff0483e5f6292b1d52777"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "dd56d17ce2f0ca176b727bf556d01bc3f0fd8daf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ab283783011f0b338394e1a5ff78dfa8075fb7d357090952ba38e09f84cb3aac"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e0ca602608f66e786359c02ec41adef903efd30c2074cce4618870f52556161f81efa88ec5e83abf3856f2b75ed61ae8d53a7b3c4c90e034c3bb41e8298c501e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "74978bea24725c9532c3877249c52801b1372290ae62b0dec9e5c84e50d1987e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6b454131472c3f269ce9eb43067fe291884fde4b95d72afa17c6e2b919e35d8ac3eec327c1d8a62b69ec4c2ee484f984c77d245958c753cfa09f992d3bc2d67b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ac8b09cc1f0d2a21ed67f8d92753341357d995c042c3d3bccd913c3e5a299aaaeb8f517ec7b8ed651a0eda4103927c4a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2db0c665ac50ba4b01b8ffa68f83035ce8ee09378323e167fe4edcb6c1e8b4f650f9cbd388f2704eb7b5ad02357fb00d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant-antunit@1.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "rfc-9116",
+          "url" : "https://ant.apache.org/.well-known/security.txt"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant-antlibs-antunit.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/job/AntUnit/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?component=AntUnit&product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/antlibs/antunit/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/antlibs/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/antlibs/srcdownload.cgi"
+        }
+      ]
+    },
+    "manufacturer" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "supplier" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "licenses" : [
+      {
+        "license" : {
+          "id" : "Apache-2.0",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      }
+    ]
+  },
+  "components" : [
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant@1.10.13?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant",
+      "version" : "1.10.13",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant@1.10.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "rfc-9116",
+          "url" : "https://ant.apache.org/.well-known/security.txt"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "advisories",
+          "url" : "https://ant.apache.org/security.html#Apache%20Ant%20Security%20Vulnerabilities"
+        },
+        {
+          "type" : "documentation",
+          "url" : "https://ant.apache.org/manual/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        },
+        {
+          "type" : "release-notes",
+          "url" : "https://github.com/apache/ant/blob/master/WHATSNEW"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant-launcher@1.10.13?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant-launcher",
+      "version" : "1.10.13",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant-launcher@1.10.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "rfc-9116",
+          "url" : "https://ant.apache.org/.well-known/security.txt"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "advisories",
+          "url" : "https://ant.apache.org/security.html#Apache%20Ant%20Security%20Vulnerabilities"
+        },
+        {
+          "type" : "documentation",
+          "url" : "https://ant.apache.org/manual/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        },
+        {
+          "type" : "release-notes",
+          "url" : "https://github.com/apache/ant/blob/master/WHATSNEW"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/junit/junit@4.13.2?type=jar",
+      "publisher" : "JUnit",
+      "group" : "junit",
+      "name" : "junit",
+      "version" : "4.13.2",
+      "description" : "JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.",
+      "scope" : "optional",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0",
+            "url" : "http://www.eclipse.org/legal/epl-v10.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/junit/junit@4.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://junit.org"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "group" : "org.hamcrest",
+      "name" : "hamcrest-core",
+      "version" : "1.3",
+      "description" : "Core API and libraries of hamcrest matcher framework.",
+      "scope" : "optional",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "url" : "https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hamcrest.org/JavaHamcrest/"
+        }
+      ]
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant-antunit@1.5.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant@1.10.13?type=jar",
+        "pkg:maven/junit/junit@4.13.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant@1.10.13?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant-launcher@1.10.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant-launcher@1.10.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/junit/junit@4.13.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/sboms/ant/maven/org.apache.ant/ant-props/1.0.0/ant-props-1.0.0.cdx.json
+++ b/sboms/ant/maven/org.apache.ant/ant-props/1.0.0/ant-props-1.0.0.cdx.json
@@ -1,0 +1,417 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:df44e38d-d103-4dcc-b918-036ca12e6998",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2026-06-20T08:20:17Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : {
+      "components" : [
+        {
+          "type" : "library",
+          "supplier" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "manufacturer" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "publisher" : "The Apache Software Foundation",
+          "group" : "org.apache.ant",
+          "name" : "ant-cyclonedx",
+          "version" : "0.1",
+          "description" : "Apache CycloneDX Antlib",
+          "hashes" : [
+            {
+              "alg" : "MD5",
+              "content" : "f00bf8afd0fd1a4677a80aa400934230"
+            },
+            {
+              "alg" : "SHA-1",
+              "content" : "64676be7248fc2ec0eef936be9c2507909e05414"
+            },
+            {
+              "alg" : "SHA-256",
+              "content" : "a4f295746ba0ea50d7b720dc4f42ffbe5a98bc3ad9f0d175a0be80a5bd108e84"
+            },
+            {
+              "alg" : "SHA-512",
+              "content" : "b0fa0bc41af224339d3bd301fe308de3bd3b0f75ad7ded60559469fa4eed85bec96e0eb195ae1db14fad2a8aaed42c776b3268575d7feeac6751a7737193cf3c"
+            },
+            {
+              "alg" : "SHA3-256",
+              "content" : "8af81f7d1cda4165dd841ef06ef5fa928a103a2de487bc62e659f98618c6f8d7"
+            },
+            {
+              "alg" : "SHA3-512",
+              "content" : "5584260043593ad9abcd6b2c9630edc65422f6b4853cc884935d995d9f4a04c6be6ad4504a38f16910fbff698f5411cbe5bbab0ee071f6011eeef51a9fa93cdb"
+            },
+            {
+              "alg" : "SHA-384",
+              "content" : "3532c340f51512b3521f96fe1f96b49cb7748c2b117ca4670dad26db8842efced5a64a366af01be2a25940eac63acf3f"
+            },
+            {
+              "alg" : "SHA3-384",
+              "content" : "64b575e8e4c5f28d77fa55aa81f031c7fa7873ccda1ab3f4429e35587c3d33cc1f66bcb9e3caae1c0945f24ab722362c"
+            }
+          ],
+          "licenses" : [
+            {
+              "license" : {
+                "id" : "Apache-2.0",
+                "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+              }
+            }
+          ],
+          "purl" : "pkg:maven/org.apache.ant/ant-cyclonedx@0.1?type=jar",
+          "externalReferences" : [
+            {
+              "type" : "vcs",
+              "url" : "https://gitbox.apache.org/repos/asf/ant-antlibs-cyclonedx.git"
+            },
+            {
+              "type" : "license",
+              "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            },
+            {
+              "type" : "build-system",
+              "url" : "https://ci-builds.apache.org/job/Ant/job/CycloneDX%20Antlib/"
+            },
+            {
+              "type" : "mailing-list",
+              "url" : "https://ant.apache.org/mail.html"
+            },
+            {
+              "type" : "issue-tracker",
+              "url" : "https://bz.apache.org/bugzilla/buglist.cgi?component=CycloneDX%20Antlib&product=Ant"
+            },
+            {
+              "type" : "website",
+              "url" : "https://ant.apache.org/antlibs/cyclonedx/"
+            },
+            {
+              "type" : "distribution",
+              "url" : "https://ant.apache.org/antlibs/bindownload.cgi"
+            },
+            {
+              "type" : "source-distribution",
+              "url" : "https://ant.apache.org/antlibs/srcdownload.cgi"
+            },
+            {
+              "type" : "security-contact",
+              "url" : "https://www.apache.org/security/"
+            }
+          ]
+        }
+      ]
+    },
+    "component" : {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant-props@1.0.0?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "manufacturer" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.ant",
+      "name" : "ant-props",
+      "version" : "1.0.0",
+      "description" : "Apache Props Antlib",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "76cfe53b26d075f44f051d6601518c50"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "da89e11da0ab59ce1b1ea5e79a220f98a73c5792"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "beedf261358956e8a2271ad7824f01adebe89709a0ffa2fa2882a8fabf777b04"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "93707e275e482bed0c7a8b950e1666561d61a4d4ceb2b2233c31516d0959d2d649a2285bd019db73734dfe8657a3368bee3cf9928f99d028c80a0eba41ddd56b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7e3671f7c6324c78e119539a28f6135a72d8dc397dd17719a6deb5bf989ed758"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7da126272b72a26c47752ea5580332e9156de4cad03cb5e06fe9b9578dd8da2710b2a7247ff6ac9f4423017793ac1cc3bb9846e33572a93dcad62399336b5319"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "30389be3ddbae4cd607e83daa833750b9015178a957eb5d6021a66af65dcb25f5413d0dba697e99e7eb438cd42d8567a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f60806857659d324663693469e4a2544a3a5d9135d7d30f56a082bc06995c465928f6764d5d26dd7337f354ffcc10c38"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant-props@1.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "rfc-9116",
+          "url" : "https://ant.apache.org/.well-known/security.txt"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/antlibs/props/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/antlibs/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/antlibs/srcdownload.cgi"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant-antlibs-props.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/job/AntLib-props/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?component=Props+Antlib&product=Ant"
+        }
+      ]
+    },
+    "manufacturer" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "supplier" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "licenses" : [
+      {
+        "license" : {
+          "id" : "Apache-2.0",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      }
+    ]
+  },
+  "components" : [
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant@1.8.0?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant",
+      "version" : "1.8.0",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant@1.8.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "rfc-9116",
+          "url" : "https://ant.apache.org/.well-known/security.txt"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "advisories",
+          "url" : "https://ant.apache.org/security.html#Apache%20Ant%20Security%20Vulnerabilities"
+        },
+        {
+          "type" : "documentation",
+          "url" : "https://ant.apache.org/manual/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        },
+        {
+          "type" : "release-notes",
+          "url" : "https://github.com/apache/ant/blob/master/WHATSNEW"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant-launcher@1.8.0?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant-launcher",
+      "version" : "1.8.0",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant-launcher@1.8.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "rfc-9116",
+          "url" : "https://ant.apache.org/.well-known/security.txt"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "advisories",
+          "url" : "https://ant.apache.org/security.html#Apache%20Ant%20Security%20Vulnerabilities"
+        },
+        {
+          "type" : "documentation",
+          "url" : "https://ant.apache.org/manual/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        },
+        {
+          "type" : "release-notes",
+          "url" : "https://github.com/apache/ant/blob/master/WHATSNEW"
+        }
+      ]
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant-props@1.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant@1.8.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant@1.8.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant-launcher@1.8.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant-launcher@1.8.0?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/sboms/ant/maven/org.apache.ivy/ivy/2.6.0/ivy-2.6.0.cdx.json
+++ b/sboms/ant/maven/org.apache.ivy/ivy/2.6.0/ivy-2.6.0.cdx.json
@@ -1,0 +1,627 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:21c5673c-68b4-475e-a6e7-19255f932b17",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2026-07-12T06:01:38Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : {
+      "components" : [
+        {
+          "type" : "library",
+          "supplier" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "manufacturer" : {
+            "name" : "Apache Ant Project Management Committee",
+            "url" : [
+              "https://ant.apache.org/"
+            ]
+          },
+          "publisher" : "The Apache Software Foundation",
+          "group" : "org.apache.ant",
+          "name" : "ant-cyclonedx",
+          "version" : "0.1",
+          "description" : "Apache CycloneDX Antlib",
+          "licenses" : [
+            {
+              "license" : {
+                "id" : "Apache-2.0",
+                "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+              }
+            }
+          ],
+          "purl" : "pkg:maven/org.apache.ant/ant-cyclonedx@0.1?type=jar",
+          "externalReferences" : [
+            {
+              "type" : "vcs",
+              "url" : "https://gitbox.apache.org/repos/asf/ant-antlibs-cyclonedx.git"
+            },
+            {
+              "type" : "license",
+              "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            },
+            {
+              "type" : "build-system",
+              "url" : "https://ci-builds.apache.org/job/Ant/job/CycloneDX%20Antlib/"
+            },
+            {
+              "type" : "mailing-list",
+              "url" : "https://ant.apache.org/mail.html"
+            },
+            {
+              "type" : "issue-tracker",
+              "url" : "https://bz.apache.org/bugzilla/buglist.cgi?component=CycloneDX%20Antlib&product=Ant"
+            },
+            {
+              "type" : "website",
+              "url" : "https://ant.apache.org/antlibs/cyclonedx/"
+            },
+            {
+              "type" : "distribution",
+              "url" : "https://ant.apache.org/antlibs/bindownload.cgi"
+            },
+            {
+              "type" : "source-distribution",
+              "url" : "https://ant.apache.org/antlibs/srcdownload.cgi"
+            },
+            {
+              "type" : "security-contact",
+              "url" : "https://www.apache.org/security/"
+            }
+          ]
+        }
+      ]
+    },
+    "component" : {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ivy/ivy@2.6.0?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "manufacturer" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.ivy",
+      "name" : "ivy",
+      "version" : "2.6.0",
+      "description" : "Apache Ivy",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "db6f18e5dbe9c39be5d2655a1e354f73"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "11a76d2e1d439170c61b47a7a13110a78c6c0824"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7e14fe77306a8cc71197cb3f1681e9e673ccc04254a5ede7e848e2248491ec78"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0e66c0908287112b8a63e468a572ea265767225422bfb17ff3ec9deaa647d2aafbf79b0fa18d021fc3a3e0f8cabc7c07e7c4e613f1d49a538987c49df836dd29"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "be088a0f17e81e2f80d25b85833292a1ce40a0b8c6cb49a8e4cb39a78590d189"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "60c21fa8682b3f80fc62f1f2b10abb5de4dd21baccd85e305e9f14007a14aeb05556c25b1d1ab10107aed356eb4b76996c0a850b02c787e8861215816b34a095"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "aeec799ca675640ebd5dba6f91782e1fd338e31be3fbd1665422c1bf87693dd6923a95db9d6526bdcc43aebcaacd6268"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "54ca1ed904a57bc7268c6f1ed34bc5389663d7810967a5d89d109da39e7c7d609c299353b8a3be8df98fd3f050e42c74"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ivy/ivy@2.6.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/ivy/mailing-lists.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant-ivy.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/job/Ivy/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/IVY"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/ivy/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/ivy/download.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/ivy/download.cgi"
+        },
+        {
+          "type" : "advisories",
+          "url" : "https://ant.apache.org/ivy/security.html"
+        }
+      ]
+    },
+    "manufacturer" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "supplier" : {
+      "name" : "Apache Ant Project Management Committee",
+      "url" : [
+        "https://ant.apache.org/"
+      ]
+    },
+    "licenses" : [
+      {
+        "license" : {
+          "id" : "Apache-2.0",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      }
+    ]
+  },
+  "components" : [
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant@1.9.16?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant",
+      "version" : "1.9.16",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant@1.9.16?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        },
+        {
+          "type" : "advisories",
+          "url" : "https://ant.apache.org/security.html#Apache%20Ant%20Security%20Vulnerabilities"
+        },
+        {
+          "type" : "documentation",
+          "url" : "https://ant.apache.org/manual/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.ant/ant-launcher@1.9.16?type=jar",
+      "supplier" : {
+        "name" : "Apache Ant Project Management Committee",
+        "url" : [
+          "https://ant.apache.org/"
+        ]
+      },
+      "group" : "org.apache.ant",
+      "name" : "ant-launcher",
+      "version" : "1.9.16",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.ant/ant-launcher@1.9.16?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "license",
+          "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        },
+        {
+          "type" : "security-contact",
+          "url" : "https://www.apache.org/security/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://ant.apache.org/mail.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/ant.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Ant/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bz.apache.org/bugzilla/buglist.cgi?product=Ant"
+        },
+        {
+          "type" : "website",
+          "url" : "https://ant.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://ant.apache.org/bindownload.cgi"
+        },
+        {
+          "type" : "source-distribution",
+          "url" : "https://ant.apache.org/srcdownload.cgi"
+        },
+        {
+          "type" : "advisories",
+          "url" : "https://ant.apache.org/security.html#Apache%20Ant%20Security%20Vulnerabilities"
+        },
+        {
+          "type" : "documentation",
+          "url" : "https://ant.apache.org/manual/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpclient",
+      "version" : "4.5.13",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-logging@1.2?type=jar",
+      "group" : "org.apache.commons",
+      "name" : "commons-logging",
+      "version" : "1.2",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-logging@1.2?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-compress@1.27.1?type=jar",
+      "group" : "org.apache.commons",
+      "name" : "commons-compress",
+      "version" : "1.27.1",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-compress@1.27.1?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-vfs2@2.2?type=jar",
+      "group" : "org.apache.commons",
+      "name" : "commons-vfs2",
+      "version" : "2.2",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-vfs2@2.2?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/oro/oro@2.0.8?type=jar",
+      "group" : "oro",
+      "name" : "oro",
+      "version" : "2.0.8",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/oro/oro@2.0.8?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.jcraft/jsch@0.1.55?type=jar",
+      "group" : "com.jcraft",
+      "name" : "jsch",
+      "version" : "0.1.55",
+      "description" : "JSch is a pure Java implementation of SSH2",
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Revised BSD",
+            "url" : "http://www.jcraft.com/jsch/LICENSE.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.jcraft/jsch@0.1.55?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jcraft.com/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.jcraft/jsch.agentproxy@0.0.9?type=jar",
+      "group" : "com.jcraft",
+      "name" : "jsch.agentproxy",
+      "version" : "0.0.9",
+      "description" : "a proxy to ssh-agent and Pageant in Java",
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Revised BSD",
+            "url" : "http://www.jcraft.com/jsch/LICENSE.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.jcraft/jsch.agentproxy@0.0.9?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jcraft.com/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.jcraft/jsch.agentproxy.connector-factory@0.0.9?type=jar",
+      "group" : "com.jcraft",
+      "name" : "jsch.agentproxy.connector-factory",
+      "version" : "0.0.9",
+      "description" : "a connector factory",
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Revised BSD",
+            "url" : "http://www.jcraft.com/jsch/LICENSE.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.jcraft/jsch.agentproxy.connector-factory@0.0.9?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jcraft.com/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.jcraft/jsch.agentproxy.jsch@0.0.9?type=jar",
+      "group" : "com.jcraft",
+      "name" : "jsch.agentproxy.jsch",
+      "version" : "0.0.9",
+      "description" : "a library to use jsch-agent-proxy with JSch",
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Revised BSD",
+            "url" : "http://www.jcraft.com/jsch/LICENSE.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.jcraft/jsch.agentproxy.jsch@0.0.9?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jcraft.com/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-codec@1.18.0?type=jar",
+      "group" : "org.apache.commons",
+      "name" : "commons-codec",
+      "version" : "1.18.0",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-codec@1.18.0?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.bouncycastle/bcpg-jdk15on@1.70?type=jar",
+      "group" : "org.bouncycastle",
+      "name" : "bcpg-jdk15on",
+      "version" : "1.70",
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Bouncy Castle Licence",
+            "url" : "https://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.bouncycastle/bcpg-jdk15on@1.70?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.70?type=jar",
+      "group" : "org.bouncycastle",
+      "name" : "bcprov-jdk15on",
+      "version" : "1.70",
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Bouncy Castle Licence",
+            "url" : "https://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.70?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.apache.ivy/ivy@2.6.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant@1.9.16?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+        "pkg:maven/org.apache.commons/commons-compress@1.27.1?type=jar",
+        "pkg:maven/org.apache.commons/commons-vfs2@2.2?type=jar",
+        "pkg:maven/oro/oro@2.0.8?type=jar",
+        "pkg:maven/com.jcraft/jsch@0.1.55?type=jar",
+        "pkg:maven/com.jcraft/jsch.agentproxy@0.0.9?type=jar",
+        "pkg:maven/com.jcraft/jsch.agentproxy.connector-factory@0.0.9?type=jar",
+        "pkg:maven/com.jcraft/jsch.agentproxy.jsch@0.0.9?type=jar",
+        "pkg:maven/org.bouncycastle/bcpg-jdk15on@1.70?type=jar",
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.70?type=jar",
+        "pkg:maven/org.apache.commons/commons-codec@1.18.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant@1.9.16?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.ant/ant-launcher@1.9.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.ant/ant-launcher@1.9.16?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.commons/commons-codec@1.18.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-logging@1.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.jcraft/jsch@0.1.55?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.jcraft/jsch.agentproxy@0.0.9?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-codec@1.18.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.bouncycastle/bcpg-jdk15on@1.70?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.70?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.70?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/scripts/collect-sboms-from-maven-central.py
+++ b/scripts/collect-sboms-from-maven-central.py
@@ -143,7 +143,7 @@ for project in projects:
         def is_sbom(name):
             # tighten to '-cyclonedx.xml' when Pekko is released with
             # https://github.com/apache/pekko/pull/1536
-            return name and (name.endswith('-cyclonedx.json') or name.endswith('-cyclonedx.xml') or (name.startswith('pekko') and name.endswith('xml')))
+            return name and (name.endswith('-cyclonedx.json') or name.endswith('-cyclonedx.xml') or name.endswith('.cdx.json') or (name.startswith('pekko') and name.endswith('xml')))
         sboms = list(filter(is_sbom, map(file_name, index)))
         if sboms:
             sbom = sboms[0]

--- a/scripts/describe-sboms.sh
+++ b/scripts/describe-sboms.sh
@@ -82,6 +82,7 @@ describeReleasesFromBasedir airflow Airflow - apache-airflow
 
 describeReleasesFromBase ant "AntUnit" ant-antunit org.apache.ant -
 describeReleasesFromBase ant "CycloneDX Antlib" ant-cyclonedx org.apache.ant -
+describeReleasesFromBase ant "Props Antlib" ant-props org.apache.ant -
 
 describeReleasesFromBase arrow Arrow -
 describeReleasesFromBase avro Avro -

--- a/scripts/describe-sboms.sh
+++ b/scripts/describe-sboms.sh
@@ -80,6 +80,7 @@ function describeReleasesFromBaseStrict() {
 
 describeReleasesFromBasedir airflow Airflow - apache-airflow
 
+describeReleasesFromBase ant "AntUnit" ant-antunit org.apache.ant -
 describeReleasesFromBase ant "CycloneDX Antlib" ant-cyclonedx org.apache.ant -
 
 describeReleasesFromBase arrow Arrow -

--- a/scripts/describe-sboms.sh
+++ b/scripts/describe-sboms.sh
@@ -82,6 +82,7 @@ describeReleasesFromBasedir airflow Airflow - apache-airflow
 
 describeReleasesFromBase ant "AntUnit" ant-antunit org.apache.ant -
 describeReleasesFromBase ant "CycloneDX Antlib" ant-cyclonedx org.apache.ant -
+describeReleasesFromBase ant "Ivy" ivy org.apache.ivy -
 describeReleasesFromBase ant "Props Antlib" ant-props org.apache.ant -
 
 describeReleasesFromBase arrow Arrow -


### PR DESCRIPTION
I've collected a few releases, Ant itself is probably coming soonish

We've decided to use .cdx.json instead of -cyclonedx.json going forward, so I modified the "downloader" to recognize the pattern as well.