### PR TITLE
Support PMCs that ship multiple projects (Apache Commons example)

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 Here is a list of pages ASF projects maintain to provide information on known security vulnerabilities. Each entry also has the security contact for reporting new vulnerabilities related to that project. Note that not all project security teams have a dedicated address for reporting new vulnerabilities.
 
-To report a vulnerability in an Apache project that is not listed below, contact the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20project%20name%20here).
+To report a vulnerability in an Apache project that is not listed below, contact the [Apache Security Team](mailto:security@apache.org?subject=Project%20name%20here).
 
 Use the tabs below to jump to projects by their initial. Every project lists a security contact; some also publish a security page and a list of advisories.
 
@@ -46,103 +46,103 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/accumulo/default.png" alt="" loading="lazy"> **Apache Accumulo**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Accumulo)
+    [security@apache.org](mailto:security@apache.org?subject=Accumulo)
   - Advisories (experimental):\
     [security.apache.org](/projects/accumulo/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/activemq/default.png" alt="" loading="lazy"> **Apache ActiveMQ**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ActiveMQ)
+    [security@apache.org](mailto:security@apache.org?subject=ActiveMQ)
   - Advisories:\
     [activemq.apache.org](https://activemq.apache.org/security-advisories)
   - Security model:
     - [Apache ActiveMQ security model](https://github.com/apache/activemq/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/age/default.png" alt="" loading="lazy"> **Apache AGE**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AGE)
+    [security@apache.org](mailto:security@apache.org?subject=AGE)
   - Advisories (experimental):\
     [security.apache.org](/projects/age/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/airavata/default.png" alt="" loading="lazy"> **Apache Airavata**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Airavata)
+    [security@apache.org](mailto:security@apache.org?subject=Airavata)
   - Advisories (experimental):\
     [security.apache.org](/projects/airavata/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/airflow/default.png" alt="" loading="lazy"> **Apache Airflow**
   - **Security contact:**\
-    [security@airflow.apache.org](mailto:security@airflow.apache.org?subject=%5BFINDING%5D)
+    [security@airflow.apache.org](mailto:security@airflow.apache.org?subject=Airflow)
   - Advisories (experimental):\
     [security.apache.org](/projects/airflow/)
   - Security model:
     - [Apache Airflow security model](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/allura/default.png" alt="" loading="lazy"> **Apache Allura**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Allura)
+    [security@apache.org](mailto:security@apache.org?subject=Allura)
   - Advisories (experimental):\
     [security.apache.org](/projects/allura/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ambari/default.png" alt="" loading="lazy"> **Apache Ambari**
   - **Security contact:**\
-    [security@ambari.apache.org](mailto:security@ambari.apache.org?subject=%5BFINDING%5D)
+    [security@ambari.apache.org](mailto:security@ambari.apache.org?subject=Ambari)
   - Advisories (experimental):\
     [security.apache.org](/projects/ambari/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/answer/default.png" alt="" loading="lazy"> **Apache Answer**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Answer)
+    [security@apache.org](mailto:security@apache.org?subject=Answer)
   - Advisories:\
     [answer.apache.org](https://answer.apache.org/community/security/)
   - Security model:
     - [Apache Answer security model](https://answer.apache.org/community/security-model)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ant/default.png" alt="" loading="lazy"> **Apache Ant**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ant)
+    [security@apache.org](mailto:security@apache.org?subject=Ant)
   - Advisories (experimental):\
     [security.apache.org](/projects/ant/)
   - Security model:
     - [Apache Ant security model](https://ant.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/apisix/default.png" alt="" loading="lazy"> **Apache APISIX**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20APISIX)
+    [security@apache.org](mailto:security@apache.org?subject=APISIX)
   - Advisories (experimental):\
     [security.apache.org](/projects/apisix/)
   - Security model:
     - [Apache APISIX security model](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/aries/default.png" alt="" loading="lazy"> **Apache Aries**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Aries)
+    [security@apache.org](mailto:security@apache.org?subject=Aries)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/arrow/default.png" alt="" loading="lazy"> **Apache Arrow**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Arrow)
+    [security@apache.org](mailto:security@apache.org?subject=Arrow)
   - Advisories (experimental):\
     [security.apache.org](/projects/arrow/)
   - Security model:
     - [Apache Arrow security model](https://arrow.apache.org/docs/dev/format/Security.html)
 - **Apache Artemis**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Artemis)
+    [security@apache.org](mailto:security@apache.org?subject=Artemis)
   - Advisories:\
     [artemis.apache.org](https://artemis.apache.org/components/artemis/security)
   - Security model:
     - [Apache Artemis security model](https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc)
 - <img class="project-logo" src="https://www.apache.org/logos/res/asterixdb/default.png" alt="" loading="lazy"> **Apache AsterixDB**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AsterixDB)
+    [security@apache.org](mailto:security@apache.org?subject=AsterixDB)
   - Advisories (experimental):\
     [security.apache.org](/projects/asterixdb/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/atlas/default.png" alt="" loading="lazy"> **Apache Atlas**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Atlas)
+    [security@apache.org](mailto:security@apache.org?subject=Atlas)
   - Advisories (experimental):\
     [security.apache.org](/projects/atlas/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/avro/default.png" alt="" loading="lazy"> **Apache Avro**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Avro)
+    [security@apache.org](mailto:security@apache.org?subject=Avro)
   - Advisories (experimental):\
     [security.apache.org](/projects/avro/)
   - Security model:
     - [Apache Avro security model](https://avro.apache.org/project/security/)
 - **Apache Axis**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Axis)
+    [security@apache.org](mailto:security@apache.org?subject=Axis)
   - Advisories (experimental):\
     [security.apache.org](/projects/axis/)
   - Security model:
@@ -155,39 +155,39 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/beam/default.png" alt="" loading="lazy"> **Apache Beam**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Beam)
+    [security@apache.org](mailto:security@apache.org?subject=Beam)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/bigtop/default.png" alt="" loading="lazy"> **Apache Bigtop**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Bigtop)
+    [security@apache.org](mailto:security@apache.org?subject=Bigtop)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/bookkeeper/default.png" alt="" loading="lazy"> **Apache BookKeeper**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20BookKeeper)
+    [security@apache.org](mailto:security@apache.org?subject=BookKeeper)
   - Advisories (experimental):\
     [security.apache.org](/projects/bookkeeper/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/brooklyn/default.png" alt="" loading="lazy"> **Apache Brooklyn**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Brooklyn)
+    [security@apache.org](mailto:security@apache.org?subject=Brooklyn)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/brpc/default.png" alt="" loading="lazy"> **Apache bRPC**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20bRPC)
+    [security@apache.org](mailto:security@apache.org?subject=bRPC)
   - Advisories (experimental):\
     [security.apache.org](/projects/brpc/)
   - Security model:
     - [Apache bRPC security model](https://github.com/apache/brpc/blob/master/THREAT_MODEL.md)
 - **Apache BuildStream**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20BuildStream)
+    [security@apache.org](mailto:security@apache.org?subject=BuildStream)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/bval/default.png" alt="" loading="lazy"> **Apache BVal**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20BVal)
+    [security@apache.org](mailto:security@apache.org?subject=BVal)
   - Advisories (experimental):\
     none so far
 
@@ -198,60 +198,60 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/calcite/default.png" alt="" loading="lazy"> **Apache Calcite**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Calcite)
+    [security@apache.org](mailto:security@apache.org?subject=Calcite)
   - Advisories (experimental):\
     [security.apache.org](/projects/calcite/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/camel/default.png" alt="" loading="lazy"> **Apache Camel**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Camel)
+    [security@apache.org](mailto:security@apache.org?subject=Camel)
   - Advisories (experimental):\
     [security.apache.org](/projects/camel/)
   - Security model:
     - [Apache Camel security model](https://camel.apache.org/manual/security-model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/carbondata/default.png" alt="" loading="lazy"> **Apache Carbondata**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Carbondata)
+    [security@apache.org](mailto:security@apache.org?subject=Carbondata)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Carbondata security model](https://carbondata.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/cassandra/default.png" alt="" loading="lazy"> **Apache Cassandra**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cassandra)
+    [security@apache.org](mailto:security@apache.org?subject=Cassandra)
   - Advisories (experimental):\
     [security.apache.org](/projects/cassandra/)
   - Security model:
     - [Apache Cassandra security model](https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/causeway/default.png" alt="" loading="lazy"> **Apache Causeway**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Causeway)
+    [security@apache.org](mailto:security@apache.org?subject=Causeway)
   - Advisories (experimental):\
     [security.apache.org](/projects/causeway/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/cayenne/default.png" alt="" loading="lazy"> **Apache Cayenne**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cayenne)
+    [security@apache.org](mailto:security@apache.org?subject=Cayenne)
   - Advisories (experimental):\
     [security.apache.org](/projects/cayenne/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/celeborn/default.png" alt="" loading="lazy"> **Apache Celeborn**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Celeborn)
+    [security@apache.org](mailto:security@apache.org?subject=Celeborn)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/celix/default.png" alt="" loading="lazy"> **Apache Celix**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Celix)
+    [security@apache.org](mailto:security@apache.org?subject=Celix)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/cloudstack/default.png" alt="" loading="lazy"> **Apache CloudStack**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CloudStack)
+    [security@apache.org](mailto:security@apache.org?subject=CloudStack)
   - Advisories (experimental):\
     [security.apache.org](/projects/cloudstack/)
   - Security model:
     - [Apache CloudStack security model](https://github.com/apache/cloudstack/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/commons/default.png" alt="" loading="lazy"> **Apache Commons**
   - **Security contact:**\
-    [security@commons.apache.org](mailto:security@commons.apache.org?subject=%5BFINDING%5D)
+    [security@commons.apache.org](mailto:security@commons.apache.org?subject=Commons)
   - Advisories:\
     [commons.apache.org](https://commons.apache.org/security.html#Known_Security_Vulnerabilities)
   - Security models:
@@ -261,34 +261,34 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     - [Apache Commons XML security model](https://commons.apache.org/sandbox/commons-xml/threat_model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/cordova/default.png" alt="" loading="lazy"> **Apache Cordova**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cordova)
+    [security@apache.org](mailto:security@apache.org?subject=Cordova)
   - Advisories (experimental):\
     [security.apache.org](/projects/cordova/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/couchdb/default.png" alt="" loading="lazy"> **Apache CouchDB**
   - **Security contact:**\
-    [security@couchdb.apache.org](mailto:security@couchdb.apache.org?subject=%5BFINDING%5D)
+    [security@couchdb.apache.org](mailto:security@couchdb.apache.org?subject=CouchDB)
   - Advisories (experimental):\
     [security.apache.org](/projects/couchdb/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/creadur/default.png" alt="" loading="lazy"> **Apache Creadur**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Creadur)
+    [security@apache.org](mailto:security@apache.org?subject=Creadur)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Creadur security model](https://github.com/apache/creadur-rat/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ctakes/default.png" alt="" loading="lazy"> **Apache cTAKES**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20cTAKES)
+    [security@apache.org](mailto:security@apache.org?subject=cTAKES)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/curator/default.png" alt="" loading="lazy"> **Apache Curator**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Curator)
+    [security@apache.org](mailto:security@apache.org?subject=Curator)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/cxf/default.png" alt="" loading="lazy"> **Apache CXF**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CXF)
+    [security@apache.org](mailto:security@apache.org?subject=CXF)
   - Advisories (experimental):\
     [security.apache.org](/projects/cxf/)
   - Security model:
@@ -301,81 +301,81 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/daffodil/default.png" alt="" loading="lazy"> **Apache Daffodil**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Daffodil)
+    [security@apache.org](mailto:security@apache.org?subject=Daffodil)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/datafu/default.png" alt="" loading="lazy"> **Apache DataFu**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DataFu)
+    [security@apache.org](mailto:security@apache.org?subject=DataFu)
   - Advisories (experimental):\
     none so far
 - **Apache DataFusion**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DataFusion)
+    [security@apache.org](mailto:security@apache.org?subject=DataFusion)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/datasketches/default.png" alt="" loading="lazy"> **Apache DataSketches**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DataSketches)
+    [security@apache.org](mailto:security@apache.org?subject=DataSketches)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/db/default.png" alt="" loading="lazy"> **Apache DB**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DB)
+    [security@apache.org](mailto:security@apache.org?subject=DB)
   - Advisories (experimental):\
     [security.apache.org](/projects/db/)
   - Security model:
     - [Apache DB security model](https://github.com/apache/db-jdo/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/deltaspike/default.png" alt="" loading="lazy"> **Apache DeltaSpike**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DeltaSpike)
+    [security@apache.org](mailto:security@apache.org?subject=DeltaSpike)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/devlake/default.png" alt="" loading="lazy"> **Apache DevLake**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DevLake)
+    [security@apache.org](mailto:security@apache.org?subject=DevLake)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache DevLake security model](https://devlake.apache.org/docs/v1.0/GettingStarted/Authentication)
 - <img class="project-logo" src="https://www.apache.org/logos/res/directory/default.png" alt="" loading="lazy"> **Apache Directory**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Directory)
+    [security@apache.org](mailto:security@apache.org?subject=Directory)
   - Advisories (experimental):\
     [security.apache.org](/projects/directory/)
   - Security model:
     - [Apache Directory security model](https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/dolphinscheduler/default.png" alt="" loading="lazy"> **Apache DolphinScheduler**
   - **Security contact:**\
-    [security@dolphinscheduler.apache.org](mailto:security@dolphinscheduler.apache.org?subject=%5BFINDING%5D)
+    [security@dolphinscheduler.apache.org](mailto:security@dolphinscheduler.apache.org?subject=DolphinScheduler)
   - Advisories (experimental):\
     [security.apache.org](/projects/dolphinscheduler/)
   - Security model:
     - [Apache DolphinScheduler security model](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/doris/default.png" alt="" loading="lazy"> **Apache Doris**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Doris)
+    [security@apache.org](mailto:security@apache.org?subject=Doris)
   - Advisories (experimental):\
     [security.apache.org](/projects/doris/)
   - Security model:
     - [Apache Doris security model](https://github.com/apache/doris/blob/master/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/drill/default.png" alt="" loading="lazy"> **Apache Drill**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Drill)
+    [security@apache.org](mailto:security@apache.org?subject=Drill)
   - Advisories (experimental):\
     [security.apache.org](/projects/drill/)
   - Security model:
     - [Apache Drill security model](https://github.com/apache/drill/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/druid/default.png" alt="" loading="lazy"> **Apache Druid**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Druid)
+    [security@apache.org](mailto:security@apache.org?subject=Druid)
   - Advisories (experimental):\
     [security.apache.org](/projects/druid/)
   - Security model:
     - [Apache Druid security model](https://druid.apache.org/docs/latest/operations/security-overview.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/dubbo/default.png" alt="" loading="lazy"> **Apache Dubbo**
   - **Security contact:**\
-    [security@dubbo.apache.org](mailto:security@dubbo.apache.org?subject=%5BFINDING%5D)
+    [security@dubbo.apache.org](mailto:security@dubbo.apache.org?subject=Dubbo)
   - Advisories (experimental):\
     [security.apache.org](/projects/dubbo/)
   - Security model:
@@ -388,19 +388,19 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/echarts/default.png" alt="" loading="lazy"> **Apache ECharts**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ECharts)
+    [security@apache.org](mailto:security@apache.org?subject=ECharts)
   - Advisories (experimental):\
     [security.apache.org](/projects/echarts/)
   - Security model:
     - [Apache ECharts security model](https://echarts.apache.org/handbook/en/best-practices/security/#)
 - **Apache Empire-db**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Empire-db)
+    [security@apache.org](mailto:security@apache.org?subject=Empire-db)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/eventmesh/default.png" alt="" loading="lazy"> **Apache EventMesh**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20EventMesh)
+    [security@apache.org](mailto:security@apache.org?subject=EventMesh)
   - Advisories (experimental):\
     [security.apache.org](/projects/eventmesh/)
 
@@ -411,53 +411,53 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/felix/default.png" alt="" loading="lazy"> **Apache Felix**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Felix)
+    [security@apache.org](mailto:security@apache.org?subject=Felix)
   - Advisories (experimental):\
     [security.apache.org](/projects/felix/)
 - **Apache Fesod (Incubating)**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fesod%20%28Incubating%29)
+    [security@apache.org](mailto:security@apache.org?subject=Fesod%20%28Incubating%29)
   - Advisories (experimental):\
     [security.apache.org](/projects/fesod/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/fineract/default.png" alt="" loading="lazy"> **Apache Fineract**
   - **Security contact:**\
-    [security@fineract.apache.org](mailto:security@fineract.apache.org?subject=%5BFINDING%5D)
+    [security@fineract.apache.org](mailto:security@fineract.apache.org?subject=Fineract)
   - Advisories:\
     [fineract.apache.org](https://fineract.apache.org/security.html)
   - Security model:
     - [Apache Fineract security model](https://github.com/apache/fineract/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/flagon/default.png" alt="" loading="lazy"> **Apache Flagon**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flagon)
+    [security@apache.org](mailto:security@apache.org?subject=Flagon)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/flex/default.png" alt="" loading="lazy"> **Apache Flex**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flex)
+    [security@apache.org](mailto:security@apache.org?subject=Flex)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/flink/default.png" alt="" loading="lazy"> **Apache Flink**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flink)
+    [security@apache.org](mailto:security@apache.org?subject=Flink)
   - Advisories:\
     [flink.apache.org](https://flink.apache.org/what-is-flink/security/)
   - Security model:
     - [Apache Flink security model](https://flink.apache.org/what-is-flink/security/)
 - **Apache Fluss (Incubating)**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fluss%20%28Incubating%29)
+    [security@apache.org](mailto:security@apache.org?subject=Fluss%20%28Incubating%29)
   - Advisories (experimental):\
     [security.apache.org](/projects/fluss/)
 - **Apache Fory**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fory)
+    [security@apache.org](mailto:security@apache.org?subject=Fory)
   - Advisories:\
     [fory.apache.org](https://fory.apache.org/security/)
   - Security model:
     - [Apache Fory security model](https://github.com/apache/fory/blob/main/docs/security/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/freemarker/default.png" alt="" loading="lazy"> **Apache FreeMarker**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20FreeMarker)
+    [security@apache.org](mailto:security@apache.org?subject=FreeMarker)
   - Advisories (experimental):\
     none so far
 
@@ -468,57 +468,57 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/geode/default.png" alt="" loading="lazy"> **Apache Geode**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Geode)
+    [security@apache.org](mailto:security@apache.org?subject=Geode)
   - Advisories (experimental):\
     [security.apache.org](/projects/geode/)
   - Security model:
     - [Apache Geode security model](https://geode.apache.org/docs/guide/20/security/security_model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/geronimo/default.png" alt="" loading="lazy"> **Apache Geronimo**
   - **Security contact:**\
-    [security@geronimo.apache.org](mailto:security@geronimo.apache.org?subject=%5BFINDING%5D)
+    [security@geronimo.apache.org](mailto:security@geronimo.apache.org?subject=Geronimo)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Geronimo security model](https://geronimo.apache.org/security-reports.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/gluten/default.png" alt="" loading="lazy"> **Apache Gluten**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gluten)
+    [security@apache.org](mailto:security@apache.org?subject=Gluten)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/gobblin/default.png" alt="" loading="lazy"> **Apache Gobblin**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gobblin)
+    [security@apache.org](mailto:security@apache.org?subject=Gobblin)
   - Advisories (experimental):\
     [security.apache.org](/projects/gobblin/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/grails/default.png" alt="" loading="lazy"> **Apache Grails**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Grails)
+    [security@apache.org](mailto:security@apache.org?subject=Grails)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Grails security model](https://github.com/apache/grails-core/blob/8.0.x/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/gravitino/default.png" alt="" loading="lazy"> **Apache Gravitino**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gravitino)
+    [security@apache.org](mailto:security@apache.org?subject=Gravitino)
   - Advisories (experimental):\
     [security.apache.org](/projects/gravitino/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/groovy/default.png" alt="" loading="lazy"> **Apache Groovy**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Groovy)
+    [security@apache.org](mailto:security@apache.org?subject=Groovy)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Groovy security model](https://github.com/apache/groovy/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/guacamole/default.png" alt="" loading="lazy"> **Apache Guacamole**
   - **Security contact:**\
-    [security@guacamole.apache.org](mailto:security@guacamole.apache.org?subject=%5BFINDING%5D)
+    [security@guacamole.apache.org](mailto:security@guacamole.apache.org?subject=Guacamole)
   - Advisories:\
     [guacamole.apache.org](https://guacamole.apache.org/security/)
   - Security model:
     - [Apache Guacamole security model](https://guacamole.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/gump/default.png" alt="" loading="lazy"> **Apache Gump**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gump)
+    [security@apache.org](mailto:security@apache.org?subject=Gump)
   - Advisories (experimental):\
     none so far
 
@@ -529,70 +529,70 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/hadoop/default.png" alt="" loading="lazy"> **Apache Hadoop**
   - **Security contact:**\
-    [security@hadoop.apache.org](mailto:security@hadoop.apache.org?subject=%5BFINDING%5D)
+    [security@hadoop.apache.org](mailto:security@hadoop.apache.org?subject=Hadoop)
   - Advisories:\
     [hadoop.apache.org](https://hadoop.apache.org/cve_list.html)
   - Security model:
     - [Apache Hadoop security model](https://github.com/apache/hadoop/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hbase/default.png" alt="" loading="lazy"> **Apache HBase**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20HBase)
+    [security@apache.org](mailto:security@apache.org?subject=HBase)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache HBase security model](https://hbase.apache.org/security-model/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/helix/default.png" alt="" loading="lazy"> **Apache Helix**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Helix)
+    [security@apache.org](mailto:security@apache.org?subject=Helix)
   - Advisories (experimental):\
     [security.apache.org](/projects/helix/)
   - Security model:
     - [Apache Helix security model](https://github.com/apache/helix/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hertzbeat/default.png" alt="" loading="lazy"> **Apache Hertzbeat**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hertzbeat)
+    [security@apache.org](mailto:security@apache.org?subject=Hertzbeat)
   - Advisories (experimental):\
     [security.apache.org](/projects/hertzbeat/)
   - Security model:
     - [Apache Hertzbeat security model](https://hertzbeat.apache.org/docs/help/security_model/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hive/default.png" alt="" loading="lazy"> **Apache Hive**
   - **Security contact:**\
-    [security@hive.apache.org](mailto:security@hive.apache.org?subject=%5BFINDING%5D)
+    [security@hive.apache.org](mailto:security@hive.apache.org?subject=Hive)
   - Advisories (experimental):\
     [security.apache.org](/projects/hive/)
   - Security model:
     - [Apache Hive security model](https://github.com/apache/hive/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hop/default.png" alt="" loading="lazy"> **Apache Hop**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hop)
+    [security@apache.org](mailto:security@apache.org?subject=Hop)
   - Advisories (experimental):\
     [security.apache.org](/projects/hop/)
   - Security model:
     - [Apache Hop security model](https://github.com/apache/hop/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/httpd/default.png" alt="" loading="lazy"> **Apache HTTP Server**
   - **Security contact:**\
-    [security@httpd.apache.org](mailto:security@httpd.apache.org?subject=%5BFINDING%5D)
+    [security@httpd.apache.org](mailto:security@httpd.apache.org?subject=HTTP%20Server)
   - Advisories:\
     [httpd.apache.org](https://httpd.apache.org/security/vulnerabilities_24.html)
   - Security model:
     - [Apache HTTP Server security model](https://github.com/apache/httpd/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/httpcomponents/default.png" alt="" loading="lazy"> **Apache HttpComponents**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20HttpComponents)
+    [security@apache.org](mailto:security@apache.org?subject=HttpComponents)
   - Advisories (experimental):\
     [security.apache.org](/projects/httpcomponents/)
   - Security model:
     - [Apache HttpComponents security model](https://hc.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hudi/default.png" alt="" loading="lazy"> **Apache Hudi**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hudi)
+    [security@apache.org](mailto:security@apache.org?subject=Hudi)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Hudi security model](https://hudi.apache.org/contribute/security)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hugegraph/default.png" alt="" loading="lazy"> **Apache HugeGraph**
   - **Security contact:**\
-    [security@hugegraph.apache.org](mailto:security@hugegraph.apache.org?subject=%5BFINDING%5D)
+    [security@hugegraph.apache.org](mailto:security@hugegraph.apache.org?subject=HugeGraph)
   - Advisories:\
     [hugegraph.apache.org](https://hugegraph.apache.org/docs/guides/security)
   - Security model:
@@ -605,35 +605,35 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/iceberg/default.png" alt="" loading="lazy"> **Apache Iceberg**
   - **Security contact:**\
-    [security@iceberg.apache.org](mailto:security@iceberg.apache.org?subject=%5BFINDING%5D)
+    [security@iceberg.apache.org](mailto:security@iceberg.apache.org?subject=Iceberg)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Iceberg security model](https://github.com/apache/iceberg/blob/main/SECURITY-THREAT-MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ignite/default.png" alt="" loading="lazy"> **Apache Ignite**
   - **Security contact:**\
-    [security@ignite.apache.org](mailto:security@ignite.apache.org?subject=%5BFINDING%5D)
+    [security@ignite.apache.org](mailto:security@ignite.apache.org?subject=Ignite)
   - Advisories (experimental):\
     [security.apache.org](/projects/ignite/)
   - Security model:
     - [Apache Ignite security model](https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model)
 - <img class="project-logo" src="https://www.apache.org/logos/res/impala/default.png" alt="" loading="lazy"> **Apache Impala**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Impala)
+    [security@apache.org](mailto:security@apache.org?subject=Impala)
   - Advisories (experimental):\
     [security.apache.org](/projects/impala/)
   - Security model:
     - [Apache Impala security model](https://github.com/apache/impala/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/inlong/default.png" alt="" loading="lazy"> **Apache InLong**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20InLong)
+    [security@apache.org](mailto:security@apache.org?subject=InLong)
   - Advisories (experimental):\
     [security.apache.org](/projects/inlong/)
   - Security model:
     - [Apache InLong security model](https://inlong.apache.org/docs/next/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/iotdb/default.png" alt="" loading="lazy"> **Apache IoTDB**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20IoTDB)
+    [security@apache.org](mailto:security@apache.org?subject=IoTDB)
   - Advisories (experimental):\
     [security.apache.org](/projects/iotdb/)
   - Security model:
@@ -646,47 +646,47 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/jackrabbit/default.png" alt="" loading="lazy"> **Apache Jackrabbit**
   - **Security contact:**\
-    [security@jackrabbit.apache.org](mailto:security@jackrabbit.apache.org?subject=%5BFINDING%5D)
+    [security@jackrabbit.apache.org](mailto:security@jackrabbit.apache.org?subject=Jackrabbit)
   - Advisories:\
     [jackrabbit.apache.org](https://jackrabbit.apache.org/jcr/security-reports.html)
   - Security model:
     - [Apache Jackrabbit security model](https://jackrabbit.apache.org/jcr/security-reports.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/james/default.png" alt="" loading="lazy"> **Apache James**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20James)
+    [security@apache.org](mailto:security@apache.org?subject=James)
   - Advisories (experimental):\
     [security.apache.org](/projects/james/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/jena/default.png" alt="" loading="lazy"> **Apache Jena**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Jena)
+    [security@apache.org](mailto:security@apache.org?subject=Jena)
   - Advisories (experimental):\
     [security.apache.org](/projects/jena/)
   - Security model:
     - [Apache Jena security model](https://github.com/apache/jena/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/jmeter/default.png" alt="" loading="lazy"> **Apache JMeter**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20JMeter)
+    [security@apache.org](mailto:security@apache.org?subject=JMeter)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache JMeter security model](https://github.com/apache/jmeter/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/johnzon/default.png" alt="" loading="lazy"> **Apache Johnzon**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Johnzon)
+    [security@apache.org](mailto:security@apache.org?subject=Johnzon)
   - Advisories (experimental):\
     [security.apache.org](/projects/johnzon/)
   - Security model:
     - [Apache Johnzon security model](https://johnzon.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/jspwiki/default.png" alt="" loading="lazy"> **Apache JSPWiki**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20JSPWiki)
+    [security@apache.org](mailto:security@apache.org?subject=JSPWiki)
   - Advisories:\
     [jspwiki-wiki.apache.org](https://jspwiki-wiki.apache.org/Wiki.jsp?page=CVE)
   - Security model:
     - [Apache JSPWiki security model](https://github.com/apache/jspwiki/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/juneau/default.png" alt="" loading="lazy"> **Apache Juneau**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Juneau)
+    [security@apache.org](mailto:security@apache.org?subject=Juneau)
   - Advisories (experimental):\
     none so far
 
@@ -697,43 +697,43 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/kafka/default.png" alt="" loading="lazy"> **Apache Kafka**
   - **Security contact:**\
-    [security@kafka.apache.org](mailto:security@kafka.apache.org?subject=%5BFINDING%5D)
+    [security@kafka.apache.org](mailto:security@kafka.apache.org?subject=Kafka)
   - Advisories:\
     [kafka.apache.org](https://kafka.apache.org/cve-list.html)
   - Security model:
     - [Apache Kafka security model](https://kafka.apache.org/project-security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/karaf/default.png" alt="" loading="lazy"> **Apache Karaf**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Karaf)
+    [security@apache.org](mailto:security@apache.org?subject=Karaf)
   - Advisories (experimental):\
     [security.apache.org](/projects/karaf/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/knox/default.png" alt="" loading="lazy"> **Apache Knox**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Knox)
+    [security@apache.org](mailto:security@apache.org?subject=Knox)
   - Advisories (experimental):\
     [security.apache.org](/projects/knox/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/kudu/default.png" alt="" loading="lazy"> **Apache Kudu**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kudu)
+    [security@apache.org](mailto:security@apache.org?subject=Kudu)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Kudu security model](https://github.com/apache/kudu/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/kvrocks/default.png" alt="" loading="lazy"> **Apache Kvrocks**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kvrocks)
+    [security@apache.org](mailto:security@apache.org?subject=Kvrocks)
   - Advisories (experimental):\
     [security.apache.org](/projects/kvrocks/)
   - Security model:
     - [Apache Kvrocks security model](https://github.com/apache/kvrocks/blob/unstable/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/kylin/default.png" alt="" loading="lazy"> **Apache Kylin**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kylin)
+    [security@apache.org](mailto:security@apache.org?subject=Kylin)
   - Advisories (experimental):\
     [security.apache.org](/projects/kylin/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/kyuubi/default.png" alt="" loading="lazy"> **Apache Kyuubi**
   - **Security contact:**\
-    [security@kyuubi.apache.org](mailto:security@kyuubi.apache.org?subject=%5BFINDING%5D)
+    [security@kyuubi.apache.org](mailto:security@kyuubi.apache.org?subject=Kyuubi)
   - Advisories (experimental):\
     [security.apache.org](/projects/kyuubi/)
 
@@ -744,36 +744,36 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/libcloud/default.png" alt="" loading="lazy"> **Apache Libcloud**
   - **Security contact:**\
-    [security@libcloud.apache.org](mailto:security@libcloud.apache.org?subject=%5BFINDING%5D)
+    [security@libcloud.apache.org](mailto:security@libcloud.apache.org?subject=Libcloud)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Libcloud security model](https://libcloud.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/linkis/default.png" alt="" loading="lazy"> **Apache Linkis**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Linkis)
+    [security@apache.org](mailto:security@apache.org?subject=Linkis)
   - Advisories (experimental):\
     [security.apache.org](/projects/linkis/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/livy/default.png" alt="" loading="lazy"> **Apache Livy**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Livy)
+    [security@apache.org](mailto:security@apache.org?subject=Livy)
   - Advisories (experimental):\
     [security.apache.org](/projects/livy/)
 - **Apache Logging**
   - **Security contact:**\
-    [security@logging.apache.org](mailto:security@logging.apache.org?subject=%5BFINDING%5D)
+    [security@logging.apache.org](mailto:security@logging.apache.org?subject=Logging)
   - Advisories:\
     [logging.apache.org](https://logging.apache.org/security.html)
   - Security model:
     - [Apache Logging security model](https://logging.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/lucene/default.png" alt="" loading="lazy"> **Apache Lucene**
   - **Security contact:**\
-    [security@lucene.apache.org](mailto:security@lucene.apache.org?subject=%5BFINDING%5D)
+    [security@lucene.apache.org](mailto:security@lucene.apache.org?subject=Lucene)
   - Advisories (experimental):\
     [security.apache.org](/projects/lucene/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/lucenenet/default.png" alt="" loading="lazy"> **Apache Lucene.NET**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Lucene.NET)
+    [security@apache.org](mailto:security@apache.org?subject=Lucene.NET)
   - Advisories (experimental):\
     [security.apache.org](/projects/lucenenet/)
 
@@ -784,51 +784,51 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/madlib/default.png" alt="" loading="lazy"> **Apache MADlib**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MADlib)
+    [security@apache.org](mailto:security@apache.org?subject=MADlib)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/magpie/default.png" alt="" loading="lazy"> **Apache Magpie**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Magpie)
+    [security@apache.org](mailto:security@apache.org?subject=Magpie)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Magpie security model](https://github.com/apache/magpie/blob/main/docs/security/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/mahout/default.png" alt="" loading="lazy"> **Apache Mahout**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Mahout)
+    [security@apache.org](mailto:security@apache.org?subject=Mahout)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/manifoldcf/default.png" alt="" loading="lazy"> **Apache ManifoldCF**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ManifoldCF)
+    [security@apache.org](mailto:security@apache.org?subject=ManifoldCF)
   - Advisories (experimental):\
     [security.apache.org](/projects/manifoldcf/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/maven/default.png" alt="" loading="lazy"> **Apache Maven**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Maven)
+    [security@apache.org](mailto:security@apache.org?subject=Maven)
   - Advisories (experimental):\
     [security.apache.org](/projects/maven/)
   - Security model:
     - [Apache Maven security model](https://github.com/apache/maven/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/mina/default.png" alt="" loading="lazy"> **Apache MINA**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MINA)
+    [security@apache.org](mailto:security@apache.org?subject=MINA)
   - Advisories (experimental):\
     [security.apache.org](/projects/mina/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/perl/default.png" alt="" loading="lazy"> **Apache mod_perl**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20mod_perl)
+    [security@apache.org](mailto:security@apache.org?subject=mod_perl)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/myfaces/default.png" alt="" loading="lazy"> **Apache MyFaces**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MyFaces)
+    [security@apache.org](mailto:security@apache.org?subject=MyFaces)
   - Advisories (experimental):\
     [security.apache.org](/projects/myfaces/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/mynewt/default.png" alt="" loading="lazy"> **Apache Mynewt**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Mynewt)
+    [security@apache.org](mailto:security@apache.org?subject=Mynewt)
   - Advisories (experimental):\
     [security.apache.org](/projects/mynewt/)
 
@@ -839,26 +839,26 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/netbeans/default.png" alt="" loading="lazy"> **Apache NetBeans**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20NetBeans)
+    [security@apache.org](mailto:security@apache.org?subject=NetBeans)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/nifi/default.png" alt="" loading="lazy"> **Apache NiFi**
   - **Security contact:**\
-    [security@nifi.apache.org](mailto:security@nifi.apache.org?subject=%5BFINDING%5D)
+    [security@nifi.apache.org](mailto:security@nifi.apache.org?subject=NiFi)
   - Advisories:\
     [nifi.apache.org](https://nifi.apache.org/documentation/security/)
   - Security model:
     - [Apache NiFi security model](https://nifi.apache.org/documentation/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/nutch/default.png" alt="" loading="lazy"> **Apache Nutch**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Nutch)
+    [security@apache.org](mailto:security@apache.org?subject=Nutch)
   - Advisories:\
     [nutch.apache.org](https://nutch.apache.org/documentation/security/#nutch-cve-list)
   - Security model:
     - [Apache Nutch security model](https://github.com/apache/nutch/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/nuttx/default.png" alt="" loading="lazy"> **Apache NuttX**
   - **Security contact:**\
-    [security@nuttx.apache.org](mailto:security@nuttx.apache.org?subject=%5BFINDING%5D)
+    [security@nuttx.apache.org](mailto:security@nuttx.apache.org?subject=NuttX)
   - Advisories:\
     [nuttx.apache.org](https://nuttx.apache.org/docs/latest/security.html#nuttx-cves)
   - Security model:
@@ -871,62 +871,62 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/ofbiz/default.png" alt="" loading="lazy"> **Apache OFBiz**
   - **Security contact:**\
-    [security@ofbiz.apache.org](mailto:security@ofbiz.apache.org?subject=%5BFINDING%5D)
+    [security@ofbiz.apache.org](mailto:security@ofbiz.apache.org?subject=OFBiz)
   - Advisories:\
     [ofbiz.apache.org](https://ofbiz.apache.org/security.html)
   - Security model:
     - [Apache OFBiz security model](https://ofbiz.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/opendal/default.png" alt="" loading="lazy"> **Apache OpenDAL**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenDAL)
+    [security@apache.org](mailto:security@apache.org?subject=OpenDAL)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache OpenDAL security model](https://github.com/apache/opendal/blob/main/SECURITY-THREAT-MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/openjpa/default.png" alt="" loading="lazy"> **Apache OpenJPA**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenJPA)
+    [security@apache.org](mailto:security@apache.org?subject=OpenJPA)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/openmeetings/default.png" alt="" loading="lazy"> **Apache OpenMeetings**
   - **Security contact:**\
-    [security@openmeetings.apache.org](mailto:security@openmeetings.apache.org?subject=%5BFINDING%5D)
+    [security@openmeetings.apache.org](mailto:security@openmeetings.apache.org?subject=OpenMeetings)
   - Advisories (experimental):\
     [security.apache.org](/projects/openmeetings/)
   - Security model:
     - [Apache OpenMeetings security model](https://openmeetings.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/opennlp/default.png" alt="" loading="lazy"> **Apache OpenNLP**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenNLP)
+    [security@apache.org](mailto:security@apache.org?subject=OpenNLP)
   - Advisories (experimental):\
     [security.apache.org](/projects/opennlp/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/openoffice/default.png" alt="" loading="lazy"> **Apache OpenOffice**
   - **Security contact:**\
-    [security@openoffice.apache.org](mailto:security@openoffice.apache.org?subject=%5BFINDING%5D)
+    [security@openoffice.apache.org](mailto:security@openoffice.apache.org?subject=OpenOffice)
   - Advisories:\
     [www.openoffice.org](https://www.openoffice.org/security/bulletin.html)
   - Security model:
     - [Apache OpenOffice security model](https://openoffice.apache.org/security)
 - <img class="project-logo" src="https://www.apache.org/logos/res/openwebbeans/default.png" alt="" loading="lazy"> **Apache OpenWebBeans**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenWebBeans)
+    [security@apache.org](mailto:security@apache.org?subject=OpenWebBeans)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/openwhisk/default.png" alt="" loading="lazy"> **Apache OpenWhisk**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenWhisk)
+    [security@apache.org](mailto:security@apache.org?subject=OpenWhisk)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/orc/default.png" alt="" loading="lazy"> **Apache ORC**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ORC)
+    [security@apache.org](mailto:security@apache.org?subject=ORC)
   - Advisories:\
     [orc.apache.org](https://orc.apache.org/security/)
   - Security model:
     - [Apache ORC security model](https://orc.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ozone/default.png" alt="" loading="lazy"> **Apache Ozone**
   - **Security contact:**\
-    [security@ozone.apache.org](mailto:security@ozone.apache.org?subject=%5BFINDING%5D)
+    [security@ozone.apache.org](mailto:security@ozone.apache.org?subject=Ozone)
   - Advisories (experimental):\
     [security.apache.org](/projects/ozone/)
   - Security model:
@@ -939,83 +939,83 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/paimon/default.png" alt="" loading="lazy"> **Apache Paimon**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Paimon)
+    [security@apache.org](mailto:security@apache.org?subject=Paimon)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Paimon security model](https://github.com/apache/paimon/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/parquet/default.png" alt="" loading="lazy"> **Apache Parquet**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Parquet)
+    [security@apache.org](mailto:security@apache.org?subject=Parquet)
   - Advisories (experimental):\
     [security.apache.org](/projects/parquet/)
   - Security model:
     - [Apache Parquet security model](https://github.com/apache/parquet-java/blob/master/SECURITY.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/pdfbox/default.png" alt="" loading="lazy"> **Apache PDFBox**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PDFBox)
+    [security@apache.org](mailto:security@apache.org?subject=PDFBox)
   - Advisories (experimental):\
     [security.apache.org](/projects/pdfbox/)
   - Security model:
     - [Apache PDFBox security model](https://pdfbox.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/pekko/default.png" alt="" loading="lazy"> **Apache Pekko**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pekko)
+    [security@apache.org](mailto:security@apache.org?subject=Pekko)
   - Advisories (experimental):\
     [security.apache.org](/projects/pekko/)
   - Security model:
     - [Apache Pekko security model](https://pekko.apache.org/docs/pekko/current/security/index.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/phoenix/default.png" alt="" loading="lazy"> **Apache Phoenix**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Phoenix)
+    [security@apache.org](mailto:security@apache.org?subject=Phoenix)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/pig/default.png" alt="" loading="lazy"> **Apache Pig**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pig)
+    [security@apache.org](mailto:security@apache.org?subject=Pig)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/pinot/default.png" alt="" loading="lazy"> **Apache Pinot**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pinot)
+    [security@apache.org](mailto:security@apache.org?subject=Pinot)
   - Advisories (experimental):\
     [security.apache.org](/projects/pinot/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/plc4x/default.png" alt="" loading="lazy"> **Apache PLC4X**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PLC4X)
+    [security@apache.org](mailto:security@apache.org?subject=PLC4X)
   - Advisories (experimental):\
     [security.apache.org](/projects/plc4x/)
   - Security model:
     - [Apache PLC4X security model](https://github.com/apache/plc4x/blob/develop/THREAT-MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/poi/default.png" alt="" loading="lazy"> **Apache POI**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20POI)
+    [security@apache.org](mailto:security@apache.org?subject=POI)
   - Advisories (experimental):\
     [security.apache.org](/projects/poi/)
   - Security model:
     - [Apache POI security model](https://poi.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/polaris/default.png" alt="" loading="lazy"> **Apache Polaris**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Polaris)
+    [security@apache.org](mailto:security@apache.org?subject=Polaris)
   - Advisories (experimental):\
     [security.apache.org](/projects/polaris/)
   - Security model:
     - [Apache Polaris security model](https://github.com/apache/polaris/blob/main/SECURITY-THREAT-MODEL.md)
 - **Apache Pony Mail**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pony%20Mail)
+    [security@apache.org](mailto:security@apache.org?subject=Pony%20Mail)
   - Advisories (experimental):\
     [security.apache.org](/projects/ponymail/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/apr/default.png" alt="" loading="lazy"> **Apache Portable Runtime (APR)**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Portable%20Runtime%20%28APR%29)
+    [security@apache.org](mailto:security@apache.org?subject=Portable%20Runtime%20%28APR%29)
   - Advisories (experimental):\
     [security.apache.org](/projects/apr/)
   - Security model:
     - [Apache Portable Runtime (APR) security model](https://apr.apache.org/security_report.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/pulsar/default.png" alt="" loading="lazy"> **Apache Pulsar**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pulsar)
+    [security@apache.org](mailto:security@apache.org?subject=Pulsar)
   - Advisories (experimental):\
     [security.apache.org](/projects/pulsar/)
   - Security model:
@@ -1028,7 +1028,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/qpid/default.png" alt="" loading="lazy"> **Apache Qpid**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Qpid)
+    [security@apache.org](mailto:security@apache.org?subject=Qpid)
   - Advisories (experimental):\
     none so far
 
@@ -1039,36 +1039,36 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/ranger/default.png" alt="" loading="lazy"> **Apache Ranger**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ranger)
+    [security@apache.org](mailto:security@apache.org?subject=Ranger)
   - Advisories:\
     [cwiki.apache.org](https://cwiki.apache.org/confluence/display/RANGER/Vulnerabilities+found+in+Ranger)
   - Security model:
     - [Apache Ranger security model](https://github.com/apache/ranger/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ratis/default.png" alt="" loading="lazy"> **Apache Ratis**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ratis)
+    [security@apache.org](mailto:security@apache.org?subject=Ratis)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/rocketmq/default.png" alt="" loading="lazy"> **Apache RocketMQ**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20RocketMQ)
+    [security@apache.org](mailto:security@apache.org?subject=RocketMQ)
   - Advisories (experimental):\
     [security.apache.org](/projects/rocketmq/)
   - Security model:
     - [Apache RocketMQ security model](https://rocketmq.apache.org/docs/security/01security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/roller/default.png" alt="" loading="lazy"> **Apache Roller**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Roller)
+    [security@apache.org](mailto:security@apache.org?subject=Roller)
   - Advisories (experimental):\
     [security.apache.org](/projects/roller/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/royale/default.png" alt="" loading="lazy"> **Apache Royale**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Royale)
+    [security@apache.org](mailto:security@apache.org?subject=Royale)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/rya/default.png" alt="" loading="lazy"> **Apache Rya**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Rya)
+    [security@apache.org](mailto:security@apache.org?subject=Rya)
   - Advisories (experimental):\
     none so far
 
@@ -1079,187 +1079,187 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/samza/default.png" alt="" loading="lazy"> **Apache Samza**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Samza)
+    [security@apache.org](mailto:security@apache.org?subject=Samza)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/santuario/default.png" alt="" loading="lazy"> **Apache Santuario**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Santuario)
+    [security@apache.org](mailto:security@apache.org?subject=Santuario)
   - Advisories (experimental):\
     [security.apache.org](/projects/santuario/)
   - Security model:
     - [Apache Santuario security model](https://github.com/apache/santuario-xml-security-java/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sdap/default.png" alt="" loading="lazy"> **Apache SDAP**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SDAP)
+    [security@apache.org](mailto:security@apache.org?subject=SDAP)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/seata/default.png" alt="" loading="lazy"> **Apache Seata**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Seata)
+    [security@apache.org](mailto:security@apache.org?subject=Seata)
   - Advisories (experimental):\
     [security.apache.org](/projects/seata/)
   - Security model:
     - [Apache Seata security model](https://seata.apache.org/docs/next/security/secret-key)
 - <img class="project-logo" src="https://www.apache.org/logos/res/seatunnel/default.png" alt="" loading="lazy"> **Apache SeaTunnel**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SeaTunnel)
+    [security@apache.org](mailto:security@apache.org?subject=SeaTunnel)
   - Advisories (experimental):\
     [security.apache.org](/projects/seatunnel/)
   - Security model:
     - [Apache SeaTunnel security model](https://seatunnel.apache.org/security)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sedona/default.png" alt="" loading="lazy"> **Apache Sedona**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Sedona)
+    [security@apache.org](mailto:security@apache.org?subject=Sedona)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/serf/default.png" alt="" loading="lazy"> **Apache Serf**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Serf)
+    [security@apache.org](mailto:security@apache.org?subject=Serf)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/servicecomb/default.png" alt="" loading="lazy"> **Apache ServiceComb**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ServiceComb)
+    [security@apache.org](mailto:security@apache.org?subject=ServiceComb)
   - Advisories (experimental):\
     [security.apache.org](/projects/servicecomb/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/shardingsphere/default.png" alt="" loading="lazy"> **Apache ShardingSphere**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShardingSphere)
+    [security@apache.org](mailto:security@apache.org?subject=ShardingSphere)
   - Advisories (experimental):\
     [security.apache.org](/projects/shardingsphere/)
   - Security model:
     - [Apache ShardingSphere security model](https://shardingsphere.apache.org/community/en/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/shenyu/default.png" alt="" loading="lazy"> **Apache ShenYu**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShenYu)
+    [security@apache.org](mailto:security@apache.org?subject=ShenYu)
   - Advisories (experimental):\
     [security.apache.org](/projects/shenyu/)
   - Security model:
     - [Apache ShenYu security model](https://github.com/apache/shenyu/blob/master/SECURITY_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/shiro/default.png" alt="" loading="lazy"> **Apache Shiro**
   - **Security contact:**\
-    [security@shiro.apache.org](mailto:security@shiro.apache.org?subject=%5BFINDING%5D)
+    [security@shiro.apache.org](mailto:security@shiro.apache.org?subject=Shiro)
   - Advisories (experimental):\
     [security.apache.org](/projects/shiro/)
   - Security model:
     - [Apache Shiro security model](https://shiro.apache.org/security-reports.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/singa/default.png" alt="" loading="lazy"> **Apache SINGA**
   - **Security contact:**\
-    [security@singa.apache.org](mailto:security@singa.apache.org?subject=%5BFINDING%5D)
+    [security@singa.apache.org](mailto:security@singa.apache.org?subject=SINGA)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache SINGA security model](https://singa.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sis/default.png" alt="" loading="lazy"> **Apache SIS**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SIS)
+    [security@apache.org](mailto:security@apache.org?subject=SIS)
   - Advisories (experimental):\
     [security.apache.org](/projects/sis/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/skywalking/default.png" alt="" loading="lazy"> **Apache SkyWalking**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SkyWalking)
+    [security@apache.org](mailto:security@apache.org?subject=SkyWalking)
   - Advisories (experimental):\
     [security.apache.org](/projects/skywalking/)
   - Security model:
     - [Apache SkyWalking security model](https://skywalking.apache.org/docs/main/next/en/security/readme/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sling/default.png" alt="" loading="lazy"> **Apache Sling**
   - **Security contact:**\
-    [security@sling.apache.org](mailto:security@sling.apache.org?subject=%5BFINDING%5D)
+    [security@sling.apache.org](mailto:security@sling.apache.org?subject=Sling)
   - Advisories (experimental):\
     [security.apache.org](/projects/sling/)
   - Security model:
     - [Apache Sling security model](https://github.com/apache/sling/blob/master/docs/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/solr/default.png" alt="" loading="lazy"> **Apache Solr**
   - **Security contact:**\
-    [security@solr.apache.org](mailto:security@solr.apache.org?subject=%5BFINDING%5D)
+    [security@solr.apache.org](mailto:security@solr.apache.org?subject=Solr)
   - Advisories:\
     [solr.apache.org](https://solr.apache.org/security.html#recent-cve-reports-for-apache-solr)
   - Security model:
     - [Apache Solr security model](https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity)
 - <img class="project-logo" src="https://www.apache.org/logos/res/spamassassin/default.png" alt="" loading="lazy"> **Apache SpamAssassin**
   - **Security contact:**\
-    [security@spamassassin.apache.org](mailto:security@spamassassin.apache.org?subject=%5BFINDING%5D)
+    [security@spamassassin.apache.org](mailto:security@spamassassin.apache.org?subject=SpamAssassin)
   - Advisories (experimental):\
     [security.apache.org](/projects/spamassassin/)
   - Security model:
     - [Apache SpamAssassin security model](https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/spark/default.png" alt="" loading="lazy"> **Apache Spark**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Spark)
+    [security@apache.org](mailto:security@apache.org?subject=Spark)
   - Advisories:\
     [spark.apache.org](https://spark.apache.org/security.html)
   - Security model:
     - [Apache Spark security model](https://spark.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/steve/default.png" alt="" loading="lazy"> **Apache Steve**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Steve)
+    [security@apache.org](mailto:security@apache.org?subject=Steve)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/storm/default.png" alt="" loading="lazy"> **Apache Storm**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Storm)
+    [security@apache.org](mailto:security@apache.org?subject=Storm)
   - Advisories (experimental):\
     [security.apache.org](/projects/storm/)
   - Security model:
     - [Apache Storm security model](https://storm.apache.org/security-model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/stormcrawler/default.png" alt="" loading="lazy"> **Apache StormCrawler**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StormCrawler)
+    [security@apache.org](mailto:security@apache.org?subject=StormCrawler)
   - Advisories:\
     [stormcrawler.apache.org](https://stormcrawler.apache.org/security/)
   - Security model:
     - [Apache StormCrawler security model](https://stormcrawler.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/streampark/default.png" alt="" loading="lazy"> **Apache StreamPark**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPark)
+    [security@apache.org](mailto:security@apache.org?subject=StreamPark)
   - Advisories (experimental):\
     [security.apache.org](/projects/streampark/)
   - Security model:
     - [Apache StreamPark security model](https://streampark.apache.org/community/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/streampipes/default.png" alt="" loading="lazy"> **Apache StreamPipes**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPipes)
+    [security@apache.org](mailto:security@apache.org?subject=StreamPipes)
   - Advisories (experimental):\
     [security.apache.org](/projects/streampipes/)
   - Security model:
     - [Apache StreamPipes security model](https://github.com/apache/streampipes/blob/dev/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/struts/default.png" alt="" loading="lazy"> **Apache Struts**
   - **Security contact:**\
-    [security@struts.apache.org](mailto:security@struts.apache.org?subject=%5BFINDING%5D)
+    [security@struts.apache.org](mailto:security@struts.apache.org?subject=Struts)
   - Advisories:\
     [cwiki.apache.org](https://cwiki.apache.org/confluence/display/WW/Security+Bulletins)
   - Security model:
     - [Apache Struts security model](https://github.com/apache/struts/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/subversion/default.png" alt="" loading="lazy"> **Apache Subversion**
   - **Security contact:**\
-    [security@subversion.apache.org](mailto:security@subversion.apache.org?subject=%5BFINDING%5D)
+    [security@subversion.apache.org](mailto:security@subversion.apache.org?subject=Subversion)
   - Advisories:\
     [subversion.apache.org](https://subversion.apache.org/security/)
   - Security model:
     - [Apache Subversion security model](https://subversion.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/superset/default.png" alt="" loading="lazy"> **Apache Superset**
   - **Security contact:**\
-    [security@superset.apache.org](mailto:security@superset.apache.org?subject=%5BFINDING%5D)
+    [security@superset.apache.org](mailto:security@superset.apache.org?subject=Superset)
   - Advisories:\
     [superset.apache.org](https://superset.apache.org/docs/security/cves)
   - Security model:
     - [Apache Superset security model](https://github.com/apache/superset/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/synapse/default.png" alt="" loading="lazy"> **Apache Synapse**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Synapse)
+    [security@apache.org](mailto:security@apache.org?subject=Synapse)
   - Advisories (experimental):\
     none so far
   - Security model:
     - [Apache Synapse security model](https://github.com/apache/synapse/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/syncope/default.png" alt="" loading="lazy"> **Apache Syncope**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Syncope)
+    [security@apache.org](mailto:security@apache.org?subject=Syncope)
   - Advisories:\
     [syncope.apache.org](https://syncope.apache.org/security)
 - **Apache SystemDS**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SystemDS)
+    [security@apache.org](mailto:security@apache.org?subject=SystemDS)
   - Advisories (experimental):\
     [security.apache.org](/projects/systemds/)
 
@@ -1270,82 +1270,82 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/tapestry/default.png" alt="" loading="lazy"> **Apache Tapestry**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tapestry)
+    [security@apache.org](mailto:security@apache.org?subject=Tapestry)
   - Advisories (experimental):\
     [security.apache.org](/projects/tapestry/)
   - Security model:
     - [Apache Tapestry security model](https://github.com/apache/tapestry-5/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tcl/default.png" alt="" loading="lazy"> **Apache Tcl**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tcl)
+    [security@apache.org](mailto:security@apache.org?subject=Tcl)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/teaclave/default.png" alt="" loading="lazy"> **Apache Teaclave**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Teaclave)
+    [security@apache.org](mailto:security@apache.org?subject=Teaclave)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/tez/default.png" alt="" loading="lazy"> **Apache Tez**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tez)
+    [security@apache.org](mailto:security@apache.org?subject=Tez)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/thrift/default.png" alt="" loading="lazy"> **Apache Thrift**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Thrift)
+    [security@apache.org](mailto:security@apache.org?subject=Thrift)
   - Advisories (experimental):\
     [security.apache.org](/projects/thrift/)
   - Security model:
     - [Apache Thrift security model](https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tika/default.png" alt="" loading="lazy"> **Apache Tika**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tika)
+    [security@apache.org](mailto:security@apache.org?subject=Tika)
   - Advisories:\
     [tika.apache.org](https://tika.apache.org/security.html)
   - Security model:
     - [Apache Tika security model](https://tika.apache.org/security-model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tinkerpop/default.png" alt="" loading="lazy"> **Apache TinkerPop**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20TinkerPop)
+    [security@apache.org](mailto:security@apache.org?subject=TinkerPop)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/tomcat/default.png" alt="" loading="lazy"> **Apache Tomcat**
   - **Security contact:**\
-    [security@tomcat.apache.org](mailto:security@tomcat.apache.org?subject=%5BFINDING%5D)
+    [security@tomcat.apache.org](mailto:security@tomcat.apache.org?subject=Tomcat)
   - Advisories:\
     [tomcat.apache.org](https://tomcat.apache.org/security.html)
   - Security model:
     - [Apache Tomcat security model](https://tomcat.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tomee/default.png" alt="" loading="lazy"> **Apache TomEE**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20TomEE)
+    [security@apache.org](mailto:security@apache.org?subject=TomEE)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/trafficserver/default.png" alt="" loading="lazy"> **Apache Traffic Server**
   - **Security contact:**\
-    [security@trafficserver.apache.org](mailto:security@trafficserver.apache.org?subject=%5BFINDING%5D)
+    [security@trafficserver.apache.org](mailto:security@trafficserver.apache.org?subject=Traffic%20Server)
   - Advisories (experimental):\
     [security.apache.org](/projects/trafficserver/)
   - Security model:
     - [Apache Traffic Server security model](https://github.com/apache/trafficserver/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/training/default.png" alt="" loading="lazy"> **Apache Training**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Training)
+    [security@apache.org](mailto:security@apache.org?subject=Training)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/tsfile/default.png" alt="" loading="lazy"> **Apache TsFile**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20TsFile)
+    [security@apache.org](mailto:security@apache.org?subject=TsFile)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/turbine/default.png" alt="" loading="lazy"> **Apache Turbine**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Turbine)
+    [security@apache.org](mailto:security@apache.org?subject=Turbine)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/tvm/default.png" alt="" loading="lazy"> **Apache TVM**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20TVM)
+    [security@apache.org](mailto:security@apache.org?subject=TVM)
   - Advisories (experimental):\
     none so far
   - Security model:
@@ -1358,17 +1358,17 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/uima/default.png" alt="" loading="lazy"> **Apache UIMA**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20UIMA)
+    [security@apache.org](mailto:security@apache.org?subject=UIMA)
   - Advisories (experimental):\
     [security.apache.org](/projects/uima/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/uniffle/default.png" alt="" loading="lazy"> **Apache Uniffle**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Uniffle)
+    [security@apache.org](mailto:security@apache.org?subject=Uniffle)
   - Advisories (experimental):\
     [security.apache.org](/projects/uniffle/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/unomi/default.png" alt="" loading="lazy"> **Apache Unomi**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Unomi)
+    [security@apache.org](mailto:security@apache.org?subject=Unomi)
   - Advisories (experimental):\
     [security.apache.org](/projects/unomi/)
   - Security model:
@@ -1381,12 +1381,12 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/vcl/default.png" alt="" loading="lazy"> **Apache VCL**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20VCL)
+    [security@apache.org](mailto:security@apache.org?subject=VCL)
   - Advisories (experimental):\
     [security.apache.org](/projects/vcl/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/velocity/default.png" alt="" loading="lazy"> **Apache Velocity**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Velocity)
+    [security@apache.org](mailto:security@apache.org?subject=Velocity)
   - Advisories (experimental):\
     [security.apache.org](/projects/velocity/)
   - Security model:
@@ -1399,22 +1399,22 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/wayang/default.png" alt="" loading="lazy"> **Apache Wayang**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Wayang)
+    [security@apache.org](mailto:security@apache.org?subject=Wayang)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/ws/default.png" alt="" loading="lazy"> **Apache Web Services**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Web%20Services)
+    [security@apache.org](mailto:security@apache.org?subject=Web%20Services)
   - Advisories (experimental):\
     [security.apache.org](/projects/ws/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/whimsy/default.png" alt="" loading="lazy"> **Apache Whimsy**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Whimsy)
+    [security@apache.org](mailto:security@apache.org?subject=Whimsy)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/wicket/default.png" alt="" loading="lazy"> **Apache Wicket**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Wicket)
+    [security@apache.org](mailto:security@apache.org?subject=Wicket)
   - Advisories (experimental):\
     [security.apache.org](/projects/wicket/)
 
@@ -1425,17 +1425,17 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/xalan/default.png" alt="" loading="lazy"> **Apache Xalan**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Xalan)
+    [security@apache.org](mailto:security@apache.org?subject=Xalan)
   - Advisories (experimental):\
     [security.apache.org](/projects/xalan/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/xerces/default.png" alt="" loading="lazy"> **Apache Xerces**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Xerces)
+    [security@apache.org](mailto:security@apache.org?subject=Xerces)
   - Advisories (experimental):\
     [security.apache.org](/projects/xerces/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/xmlgraphics/default.png" alt="" loading="lazy"> **Apache XML Graphics**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20XML%20Graphics)
+    [security@apache.org](mailto:security@apache.org?subject=XML%20Graphics)
   - Advisories (experimental):\
     [security.apache.org](/projects/xmlgraphics/)
   - Security model:
@@ -1448,12 +1448,12 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/yetus/default.png" alt="" loading="lazy"> **Apache Yetus**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Yetus)
+    [security@apache.org](mailto:security@apache.org?subject=Yetus)
   - Advisories (experimental):\
     none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/yunikorn/default.png" alt="" loading="lazy"> **Apache YuniKorn**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20YuniKorn)
+    [security@apache.org](mailto:security@apache.org?subject=YuniKorn)
   - Advisories (experimental):\
     none so far
 
@@ -1464,14 +1464,14 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
 
 - <img class="project-logo" src="https://www.apache.org/logos/res/zeppelin/default.png" alt="" loading="lazy"> **Apache Zeppelin**
   - **Security contact:**\
-    [security@zeppelin.apache.org](mailto:security@zeppelin.apache.org?subject=%5BFINDING%5D)
+    [security@zeppelin.apache.org](mailto:security@zeppelin.apache.org?subject=Zeppelin)
   - Advisories (experimental):\
     [security.apache.org](/projects/zeppelin/)
   - Security model:
     - [Apache Zeppelin security model](https://github.com/apache/zeppelin/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/zookeeper/default.png" alt="" loading="lazy"> **Apache ZooKeeper**
   - **Security contact:**\
-    [security@zookeeper.apache.org](mailto:security@zookeeper.apache.org?subject=%5BFINDING%5D)
+    [security@zookeeper.apache.org](mailto:security@zookeeper.apache.org?subject=ZooKeeper)
   - Advisories (experimental):\
     [security.apache.org](/projects/zookeeper/)
   - Security model:

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -54,8 +54,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ActiveMQ)
   - Advisories:\
     [activemq.apache.org](https://activemq.apache.org/security-advisories)
-  - Security page:\
-    [github.com](https://github.com/apache/activemq/security/policy)
+  - Security model:
+    - [Apache ActiveMQ security model](https://github.com/apache/activemq/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/age/default.png" alt="" loading="lazy"> **Apache AGE**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AGE)
@@ -71,8 +71,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@airflow.apache.org](mailto:security@airflow.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/airflow/)
-  - Security page:\
-    [airflow.apache.org](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html)
+  - Security model:
+    - [Apache Airflow security model](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/allura/default.png" alt="" loading="lazy"> **Apache Allura**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Allura)
@@ -88,22 +88,22 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Answer)
   - Advisories:\
     [answer.apache.org](https://answer.apache.org/community/security/)
-  - Security page:\
-    [answer.apache.org](https://answer.apache.org/community/security-model)
+  - Security model:
+    - [Apache Answer security model](https://answer.apache.org/community/security-model)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ant/default.png" alt="" loading="lazy"> **Apache Ant**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ant)
   - Advisories (experimental):\
     [security.apache.org](/projects/ant/)
-  - Security page:\
-    [ant.apache.org](https://ant.apache.org/security.html)
+  - Security model:
+    - [Apache Ant security model](https://ant.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/apisix/default.png" alt="" loading="lazy"> **Apache APISIX**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20APISIX)
   - Advisories (experimental):\
     [security.apache.org](/projects/apisix/)
-  - Security page:\
-    [github.com](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache APISIX security model](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/aries/default.png" alt="" loading="lazy"> **Apache Aries**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Aries)
@@ -114,15 +114,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Arrow)
   - Advisories (experimental):\
     [security.apache.org](/projects/arrow/)
-  - Security page:\
-    [arrow.apache.org](https://arrow.apache.org/docs/dev/format/Security.html)
+  - Security model:
+    - [Apache Arrow security model](https://arrow.apache.org/docs/dev/format/Security.html)
 - **Apache Artemis**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Artemis)
   - Advisories:\
     [artemis.apache.org](https://artemis.apache.org/components/artemis/security)
-  - Security page:\
-    [github.com](https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc)
+  - Security model:
+    - [Apache Artemis security model](https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc)
 - <img class="project-logo" src="https://www.apache.org/logos/res/asterixdb/default.png" alt="" loading="lazy"> **Apache AsterixDB**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AsterixDB)
@@ -138,15 +138,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Avro)
   - Advisories (experimental):\
     [security.apache.org](/projects/avro/)
-  - Security page:\
-    [avro.apache.org](https://avro.apache.org/project/security/)
+  - Security model:
+    - [Apache Avro security model](https://avro.apache.org/project/security/)
 - **Apache Axis**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Axis)
   - Advisories (experimental):\
     [security.apache.org](/projects/axis/)
-  - Security page:\
-    [github.com](https://github.com/apache/axis-axis2-java-core/security/policy)
+  - Security model:
+    - [Apache Axis security model](https://github.com/apache/axis-axis2-java-core/security/policy)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="B">
@@ -178,8 +178,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20bRPC)
   - Advisories (experimental):\
     [security.apache.org](/projects/brpc/)
-  - Security page:\
-    [github.com](https://github.com/apache/brpc/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache bRPC security model](https://github.com/apache/brpc/blob/master/THREAT_MODEL.md)
 - **Apache BuildStream**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20BuildStream)
@@ -206,22 +206,22 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Camel)
   - Advisories (experimental):\
     [security.apache.org](/projects/camel/)
-  - Security page:\
-    [camel.apache.org](https://camel.apache.org/manual/security-model.html)
+  - Security model:
+    - [Apache Camel security model](https://camel.apache.org/manual/security-model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/carbondata/default.png" alt="" loading="lazy"> **Apache Carbondata**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Carbondata)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [carbondata.apache.org](https://carbondata.apache.org/security.html)
+  - Security model:
+    - [Apache Carbondata security model](https://carbondata.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/cassandra/default.png" alt="" loading="lazy"> **Apache Cassandra**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cassandra)
   - Advisories (experimental):\
     [security.apache.org](/projects/cassandra/)
-  - Security page:\
-    [cassandra.apache.org](https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html)
+  - Security model:
+    - [Apache Cassandra security model](https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/causeway/default.png" alt="" loading="lazy"> **Apache Causeway**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Causeway)
@@ -247,15 +247,18 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CloudStack)
   - Advisories (experimental):\
     [security.apache.org](/projects/cloudstack/)
-  - Security page:\
-    [github.com](https://github.com/apache/cloudstack/blob/main/THREAT_MODEL.md)
+  - Security model:
+    - [Apache CloudStack security model](https://github.com/apache/cloudstack/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/commons/default.png" alt="" loading="lazy"> **Apache Commons**
   - **Security contact:**\
     [security@commons.apache.org](mailto:security@commons.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [commons.apache.org](https://commons.apache.org/security.html#Known_Security_Vulnerabilities)
-  - Security page:\
-    [commons.apache.org](https://commons.apache.org/security.html)
+  - Security models:
+    - [Apache Commons security model](https://commons.apache.org/threat_model.html)
+    - [Apache Commons Configuration security model](https://commons.apache.org/proper/commons-configuration/security.html)
+    - [Apache Commons Imaging security model](https://commons.apache.org/proper/commons-imaging/security.html)
+    - [Apache Commons XML security model](https://commons.apache.org/sandbox/commons-xml/threat_model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/cordova/default.png" alt="" loading="lazy"> **Apache Cordova**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cordova)
@@ -271,8 +274,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Creadur)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/creadur-rat/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Creadur security model](https://github.com/apache/creadur-rat/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ctakes/default.png" alt="" loading="lazy"> **Apache cTAKES**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20cTAKES)
@@ -288,8 +291,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CXF)
   - Advisories (experimental):\
     [security.apache.org](/projects/cxf/)
-  - Security page:\
-    [github.com](https://github.com/apache/cxf/blob/main/THREAT_MODEL.md)
+  - Security model:
+    - [Apache CXF security model](https://github.com/apache/cxf/blob/main/THREAT_MODEL.md)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="D">
@@ -321,8 +324,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DB)
   - Advisories (experimental):\
     [security.apache.org](/projects/db/)
-  - Security page:\
-    [github.com](https://github.com/apache/db-jdo/blob/main/THREAT_MODEL.md)
+  - Security model:
+    - [Apache DB security model](https://github.com/apache/db-jdo/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/deltaspike/default.png" alt="" loading="lazy"> **Apache DeltaSpike**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DeltaSpike)
@@ -333,50 +336,50 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DevLake)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [devlake.apache.org](https://devlake.apache.org/docs/v1.0/GettingStarted/Authentication)
+  - Security model:
+    - [Apache DevLake security model](https://devlake.apache.org/docs/v1.0/GettingStarted/Authentication)
 - <img class="project-logo" src="https://www.apache.org/logos/res/directory/default.png" alt="" loading="lazy"> **Apache Directory**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Directory)
   - Advisories (experimental):\
     [security.apache.org](/projects/directory/)
-  - Security page:\
-    [github.com](https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Directory security model](https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/dolphinscheduler/default.png" alt="" loading="lazy"> **Apache DolphinScheduler**
   - **Security contact:**\
     [security@dolphinscheduler.apache.org](mailto:security@dolphinscheduler.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/dolphinscheduler/)
-  - Security page:\
-    [github.com](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md)
+  - Security model:
+    - [Apache DolphinScheduler security model](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/doris/default.png" alt="" loading="lazy"> **Apache Doris**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Doris)
   - Advisories (experimental):\
     [security.apache.org](/projects/doris/)
-  - Security page:\
-    [github.com](https://github.com/apache/doris/blob/master/threat-model.md)
+  - Security model:
+    - [Apache Doris security model](https://github.com/apache/doris/blob/master/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/drill/default.png" alt="" loading="lazy"> **Apache Drill**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Drill)
   - Advisories (experimental):\
     [security.apache.org](/projects/drill/)
-  - Security page:\
-    [github.com](https://github.com/apache/drill/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Drill security model](https://github.com/apache/drill/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/druid/default.png" alt="" loading="lazy"> **Apache Druid**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Druid)
   - Advisories (experimental):\
     [security.apache.org](/projects/druid/)
-  - Security page:\
-    [druid.apache.org](https://druid.apache.org/docs/latest/operations/security-overview.html)
+  - Security model:
+    - [Apache Druid security model](https://druid.apache.org/docs/latest/operations/security-overview.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/dubbo/default.png" alt="" loading="lazy"> **Apache Dubbo**
   - **Security contact:**\
     [security@dubbo.apache.org](mailto:security@dubbo.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/dubbo/)
-  - Security page:\
-    [github.com](https://github.com/apache/dubbo/blob/3.3/docs/threat-model.md)
+  - Security model:
+    - [Apache Dubbo security model](https://github.com/apache/dubbo/blob/3.3/docs/threat-model.md)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="E">
@@ -388,8 +391,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ECharts)
   - Advisories (experimental):\
     [security.apache.org](/projects/echarts/)
-  - Security page:\
-    [echarts.apache.org](https://echarts.apache.org/handbook/en/best-practices/security/#)
+  - Security model:
+    - [Apache ECharts security model](https://echarts.apache.org/handbook/en/best-practices/security/#)
 - **Apache Empire-db**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Empire-db)
@@ -421,8 +424,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@fineract.apache.org](mailto:security@fineract.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [fineract.apache.org](https://fineract.apache.org/security.html)
-  - Security page:\
-    [github.com](https://github.com/apache/fineract/security/policy)
+  - Security model:
+    - [Apache Fineract security model](https://github.com/apache/fineract/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/flagon/default.png" alt="" loading="lazy"> **Apache Flagon**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flagon)
@@ -438,8 +441,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flink)
   - Advisories:\
     [flink.apache.org](https://flink.apache.org/what-is-flink/security/)
-  - Security page:\
-    [flink.apache.org](https://flink.apache.org/what-is-flink/security/)
+  - Security model:
+    - [Apache Flink security model](https://flink.apache.org/what-is-flink/security/)
 - **Apache Fluss (Incubating)**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fluss%20%28Incubating%29)
@@ -450,8 +453,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fory)
   - Advisories:\
     [fory.apache.org](https://fory.apache.org/security/)
-  - Security page:\
-    [github.com](https://github.com/apache/fory/blob/main/docs/security/threat-model.md)
+  - Security model:
+    - [Apache Fory security model](https://github.com/apache/fory/blob/main/docs/security/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/freemarker/default.png" alt="" loading="lazy"> **Apache FreeMarker**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20FreeMarker)
@@ -468,15 +471,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Geode)
   - Advisories (experimental):\
     [security.apache.org](/projects/geode/)
-  - Security page:\
-    [geode.apache.org](https://geode.apache.org/docs/guide/20/security/security_model.html)
+  - Security model:
+    - [Apache Geode security model](https://geode.apache.org/docs/guide/20/security/security_model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/geronimo/default.png" alt="" loading="lazy"> **Apache Geronimo**
   - **Security contact:**\
     [security@geronimo.apache.org](mailto:security@geronimo.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [geronimo.apache.org](https://geronimo.apache.org/security-reports.html)
+  - Security model:
+    - [Apache Geronimo security model](https://geronimo.apache.org/security-reports.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/gluten/default.png" alt="" loading="lazy"> **Apache Gluten**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gluten)
@@ -492,8 +495,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Grails)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/grails-core/blob/8.0.x/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Grails security model](https://github.com/apache/grails-core/blob/8.0.x/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/gravitino/default.png" alt="" loading="lazy"> **Apache Gravitino**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gravitino)
@@ -504,15 +507,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Groovy)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/groovy/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Groovy security model](https://github.com/apache/groovy/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/guacamole/default.png" alt="" loading="lazy"> **Apache Guacamole**
   - **Security contact:**\
     [security@guacamole.apache.org](mailto:security@guacamole.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [guacamole.apache.org](https://guacamole.apache.org/security/)
-  - Security page:\
-    [guacamole.apache.org](https://guacamole.apache.org/security/)
+  - Security model:
+    - [Apache Guacamole security model](https://guacamole.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/gump/default.png" alt="" loading="lazy"> **Apache Gump**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gump)
@@ -529,71 +532,71 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@hadoop.apache.org](mailto:security@hadoop.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [hadoop.apache.org](https://hadoop.apache.org/cve_list.html)
-  - Security page:\
-    [github.com](https://github.com/apache/hadoop/security/policy)
+  - Security model:
+    - [Apache Hadoop security model](https://github.com/apache/hadoop/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hbase/default.png" alt="" loading="lazy"> **Apache HBase**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20HBase)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [hbase.apache.org](https://hbase.apache.org/security-model/)
+  - Security model:
+    - [Apache HBase security model](https://hbase.apache.org/security-model/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/helix/default.png" alt="" loading="lazy"> **Apache Helix**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Helix)
   - Advisories (experimental):\
     [security.apache.org](/projects/helix/)
-  - Security page:\
-    [github.com](https://github.com/apache/helix/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Helix security model](https://github.com/apache/helix/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hertzbeat/default.png" alt="" loading="lazy"> **Apache Hertzbeat**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hertzbeat)
   - Advisories (experimental):\
     [security.apache.org](/projects/hertzbeat/)
-  - Security page:\
-    [hertzbeat.apache.org](https://hertzbeat.apache.org/docs/help/security_model/)
+  - Security model:
+    - [Apache Hertzbeat security model](https://hertzbeat.apache.org/docs/help/security_model/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hive/default.png" alt="" loading="lazy"> **Apache Hive**
   - **Security contact:**\
     [security@hive.apache.org](mailto:security@hive.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/hive/)
-  - Security page:\
-    [github.com](https://github.com/apache/hive/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Hive security model](https://github.com/apache/hive/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hop/default.png" alt="" loading="lazy"> **Apache Hop**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hop)
   - Advisories (experimental):\
     [security.apache.org](/projects/hop/)
-  - Security page:\
-    [github.com](https://github.com/apache/hop/blob/main/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Hop security model](https://github.com/apache/hop/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/httpd/default.png" alt="" loading="lazy"> **Apache HTTP Server**
   - **Security contact:**\
     [security@httpd.apache.org](mailto:security@httpd.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [httpd.apache.org](https://httpd.apache.org/security/vulnerabilities_24.html)
-  - Security page:\
-    [github.com](https://github.com/apache/httpd/security/policy)
+  - Security model:
+    - [Apache HTTP Server security model](https://github.com/apache/httpd/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/httpcomponents/default.png" alt="" loading="lazy"> **Apache HttpComponents**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20HttpComponents)
   - Advisories (experimental):\
     [security.apache.org](/projects/httpcomponents/)
-  - Security page:\
-    [hc.apache.org](https://hc.apache.org/security.html)
+  - Security model:
+    - [Apache HttpComponents security model](https://hc.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hudi/default.png" alt="" loading="lazy"> **Apache Hudi**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hudi)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [hudi.apache.org](https://hudi.apache.org/contribute/security)
+  - Security model:
+    - [Apache Hudi security model](https://hudi.apache.org/contribute/security)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hugegraph/default.png" alt="" loading="lazy"> **Apache HugeGraph**
   - **Security contact:**\
     [security@hugegraph.apache.org](mailto:security@hugegraph.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [hugegraph.apache.org](https://hugegraph.apache.org/docs/guides/security)
-  - Security page:\
-    [hugegraph.apache.org](https://hugegraph.apache.org/docs/guides/security)
+  - Security model:
+    - [Apache HugeGraph security model](https://hugegraph.apache.org/docs/guides/security)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="I">
@@ -605,36 +608,36 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@iceberg.apache.org](mailto:security@iceberg.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/iceberg/blob/main/SECURITY-THREAT-MODEL.md)
+  - Security model:
+    - [Apache Iceberg security model](https://github.com/apache/iceberg/blob/main/SECURITY-THREAT-MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ignite/default.png" alt="" loading="lazy"> **Apache Ignite**
   - **Security contact:**\
     [security@ignite.apache.org](mailto:security@ignite.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/ignite/)
-  - Security page:\
-    [ignite.apache.org](https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model)
+  - Security model:
+    - [Apache Ignite security model](https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model)
 - <img class="project-logo" src="https://www.apache.org/logos/res/impala/default.png" alt="" loading="lazy"> **Apache Impala**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Impala)
   - Advisories (experimental):\
     [security.apache.org](/projects/impala/)
-  - Security page:\
-    [github.com](https://github.com/apache/impala/security/policy)
+  - Security model:
+    - [Apache Impala security model](https://github.com/apache/impala/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/inlong/default.png" alt="" loading="lazy"> **Apache InLong**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20InLong)
   - Advisories (experimental):\
     [security.apache.org](/projects/inlong/)
-  - Security page:\
-    [inlong.apache.org](https://inlong.apache.org/docs/next/security/)
+  - Security model:
+    - [Apache InLong security model](https://inlong.apache.org/docs/next/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/iotdb/default.png" alt="" loading="lazy"> **Apache IoTDB**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20IoTDB)
   - Advisories (experimental):\
     [security.apache.org](/projects/iotdb/)
-  - Security page:\
-    [github.com](https://github.com/apache/iotdb/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache IoTDB security model](https://github.com/apache/iotdb/blob/master/THREAT_MODEL.md)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="J">
@@ -646,8 +649,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@jackrabbit.apache.org](mailto:security@jackrabbit.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [jackrabbit.apache.org](https://jackrabbit.apache.org/jcr/security-reports.html)
-  - Security page:\
-    [jackrabbit.apache.org](https://jackrabbit.apache.org/jcr/security-reports.html)
+  - Security model:
+    - [Apache Jackrabbit security model](https://jackrabbit.apache.org/jcr/security-reports.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/james/default.png" alt="" loading="lazy"> **Apache James**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20James)
@@ -658,29 +661,29 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Jena)
   - Advisories (experimental):\
     [security.apache.org](/projects/jena/)
-  - Security page:\
-    [github.com](https://github.com/apache/jena/blob/main/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Jena security model](https://github.com/apache/jena/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/jmeter/default.png" alt="" loading="lazy"> **Apache JMeter**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20JMeter)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/jmeter/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache JMeter security model](https://github.com/apache/jmeter/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/johnzon/default.png" alt="" loading="lazy"> **Apache Johnzon**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Johnzon)
   - Advisories (experimental):\
     [security.apache.org](/projects/johnzon/)
-  - Security page:\
-    [johnzon.apache.org](https://johnzon.apache.org/security.html)
+  - Security model:
+    - [Apache Johnzon security model](https://johnzon.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/jspwiki/default.png" alt="" loading="lazy"> **Apache JSPWiki**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20JSPWiki)
   - Advisories:\
     [jspwiki-wiki.apache.org](https://jspwiki-wiki.apache.org/Wiki.jsp?page=CVE)
-  - Security page:\
-    [github.com](https://github.com/apache/jspwiki/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache JSPWiki security model](https://github.com/apache/jspwiki/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/juneau/default.png" alt="" loading="lazy"> **Apache Juneau**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Juneau)
@@ -697,8 +700,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@kafka.apache.org](mailto:security@kafka.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [kafka.apache.org](https://kafka.apache.org/cve-list.html)
-  - Security page:\
-    [kafka.apache.org](https://kafka.apache.org/project-security.html)
+  - Security model:
+    - [Apache Kafka security model](https://kafka.apache.org/project-security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/karaf/default.png" alt="" loading="lazy"> **Apache Karaf**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Karaf)
@@ -714,15 +717,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kudu)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/kudu/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Kudu security model](https://github.com/apache/kudu/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/kvrocks/default.png" alt="" loading="lazy"> **Apache Kvrocks**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kvrocks)
   - Advisories (experimental):\
     [security.apache.org](/projects/kvrocks/)
-  - Security page:\
-    [github.com](https://github.com/apache/kvrocks/blob/unstable/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Kvrocks security model](https://github.com/apache/kvrocks/blob/unstable/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/kylin/default.png" alt="" loading="lazy"> **Apache Kylin**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kylin)
@@ -744,8 +747,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@libcloud.apache.org](mailto:security@libcloud.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [libcloud.apache.org](https://libcloud.apache.org/security.html)
+  - Security model:
+    - [Apache Libcloud security model](https://libcloud.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/linkis/default.png" alt="" loading="lazy"> **Apache Linkis**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Linkis)
@@ -761,8 +764,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@logging.apache.org](mailto:security@logging.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [logging.apache.org](https://logging.apache.org/security.html)
-  - Security page:\
-    [logging.apache.org](https://logging.apache.org/security.html)
+  - Security model:
+    - [Apache Logging security model](https://logging.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/lucene/default.png" alt="" loading="lazy"> **Apache Lucene**
   - **Security contact:**\
     [security@lucene.apache.org](mailto:security@lucene.apache.org?subject=%5BFINDING%5D)
@@ -789,8 +792,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Magpie)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/magpie/blob/main/docs/security/threat-model.md)
+  - Security model:
+    - [Apache Magpie security model](https://github.com/apache/magpie/blob/main/docs/security/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/mahout/default.png" alt="" loading="lazy"> **Apache Mahout**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Mahout)
@@ -806,8 +809,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Maven)
   - Advisories (experimental):\
     [security.apache.org](/projects/maven/)
-  - Security page:\
-    [github.com](https://github.com/apache/maven/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Maven security model](https://github.com/apache/maven/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/mina/default.png" alt="" loading="lazy"> **Apache MINA**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MINA)
@@ -844,22 +847,22 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@nifi.apache.org](mailto:security@nifi.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [nifi.apache.org](https://nifi.apache.org/documentation/security/)
-  - Security page:\
-    [nifi.apache.org](https://nifi.apache.org/documentation/security/)
+  - Security model:
+    - [Apache NiFi security model](https://nifi.apache.org/documentation/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/nutch/default.png" alt="" loading="lazy"> **Apache Nutch**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Nutch)
   - Advisories:\
     [nutch.apache.org](https://nutch.apache.org/documentation/security/#nutch-cve-list)
-  - Security page:\
-    [github.com](https://github.com/apache/nutch/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Nutch security model](https://github.com/apache/nutch/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/nuttx/default.png" alt="" loading="lazy"> **Apache NuttX**
   - **Security contact:**\
     [security@nuttx.apache.org](mailto:security@nuttx.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [nuttx.apache.org](https://nuttx.apache.org/docs/latest/security.html#nuttx-cves)
-  - Security page:\
-    [nuttx.apache.org](https://nuttx.apache.org/docs/latest/security.html)
+  - Security model:
+    - [Apache NuttX security model](https://nuttx.apache.org/docs/latest/security.html)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="O">
@@ -871,15 +874,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@ofbiz.apache.org](mailto:security@ofbiz.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [ofbiz.apache.org](https://ofbiz.apache.org/security.html)
-  - Security page:\
-    [ofbiz.apache.org](https://ofbiz.apache.org/security.html)
+  - Security model:
+    - [Apache OFBiz security model](https://ofbiz.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/opendal/default.png" alt="" loading="lazy"> **Apache OpenDAL**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenDAL)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/opendal/blob/main/SECURITY-THREAT-MODEL.md)
+  - Security model:
+    - [Apache OpenDAL security model](https://github.com/apache/opendal/blob/main/SECURITY-THREAT-MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/openjpa/default.png" alt="" loading="lazy"> **Apache OpenJPA**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenJPA)
@@ -890,8 +893,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@openmeetings.apache.org](mailto:security@openmeetings.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/openmeetings/)
-  - Security page:\
-    [openmeetings.apache.org](https://openmeetings.apache.org/security.html)
+  - Security model:
+    - [Apache OpenMeetings security model](https://openmeetings.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/opennlp/default.png" alt="" loading="lazy"> **Apache OpenNLP**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenNLP)
@@ -902,8 +905,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@openoffice.apache.org](mailto:security@openoffice.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [www.openoffice.org](https://www.openoffice.org/security/bulletin.html)
-  - Security page:\
-    [openoffice.apache.org](https://openoffice.apache.org/security)
+  - Security model:
+    - [Apache OpenOffice security model](https://openoffice.apache.org/security)
 - <img class="project-logo" src="https://www.apache.org/logos/res/openwebbeans/default.png" alt="" loading="lazy"> **Apache OpenWebBeans**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenWebBeans)
@@ -919,15 +922,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ORC)
   - Advisories:\
     [orc.apache.org](https://orc.apache.org/security/)
-  - Security page:\
-    [orc.apache.org](https://orc.apache.org/security/)
+  - Security model:
+    - [Apache ORC security model](https://orc.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ozone/default.png" alt="" loading="lazy"> **Apache Ozone**
   - **Security contact:**\
     [security@ozone.apache.org](mailto:security@ozone.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/ozone/)
-  - Security page:\
-    [github.com](https://github.com/apache/ozone/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Ozone security model](https://github.com/apache/ozone/blob/master/THREAT_MODEL.md)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="P">
@@ -939,29 +942,29 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Paimon)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/paimon/security/policy)
+  - Security model:
+    - [Apache Paimon security model](https://github.com/apache/paimon/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/parquet/default.png" alt="" loading="lazy"> **Apache Parquet**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Parquet)
   - Advisories (experimental):\
     [security.apache.org](/projects/parquet/)
-  - Security page:\
-    [github.com](https://github.com/apache/parquet-java/blob/master/SECURITY.md)
+  - Security model:
+    - [Apache Parquet security model](https://github.com/apache/parquet-java/blob/master/SECURITY.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/pdfbox/default.png" alt="" loading="lazy"> **Apache PDFBox**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PDFBox)
   - Advisories (experimental):\
     [security.apache.org](/projects/pdfbox/)
-  - Security page:\
-    [pdfbox.apache.org](https://pdfbox.apache.org/security.html)
+  - Security model:
+    - [Apache PDFBox security model](https://pdfbox.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/pekko/default.png" alt="" loading="lazy"> **Apache Pekko**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pekko)
   - Advisories (experimental):\
     [security.apache.org](/projects/pekko/)
-  - Security page:\
-    [pekko.apache.org](https://pekko.apache.org/docs/pekko/current/security/index.html)
+  - Security model:
+    - [Apache Pekko security model](https://pekko.apache.org/docs/pekko/current/security/index.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/phoenix/default.png" alt="" loading="lazy"> **Apache Phoenix**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Phoenix)
@@ -982,22 +985,22 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PLC4X)
   - Advisories (experimental):\
     [security.apache.org](/projects/plc4x/)
-  - Security page:\
-    [github.com](https://github.com/apache/plc4x/blob/develop/THREAT-MODEL.md)
+  - Security model:
+    - [Apache PLC4X security model](https://github.com/apache/plc4x/blob/develop/THREAT-MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/poi/default.png" alt="" loading="lazy"> **Apache POI**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20POI)
   - Advisories (experimental):\
     [security.apache.org](/projects/poi/)
-  - Security page:\
-    [poi.apache.org](https://poi.apache.org/security.html)
+  - Security model:
+    - [Apache POI security model](https://poi.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/polaris/default.png" alt="" loading="lazy"> **Apache Polaris**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Polaris)
   - Advisories (experimental):\
     [security.apache.org](/projects/polaris/)
-  - Security page:\
-    [github.com](https://github.com/apache/polaris/blob/main/SECURITY-THREAT-MODEL.md)
+  - Security model:
+    - [Apache Polaris security model](https://github.com/apache/polaris/blob/main/SECURITY-THREAT-MODEL.md)
 - **Apache Pony Mail**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pony%20Mail)
@@ -1008,15 +1011,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Portable%20Runtime%20%28APR%29)
   - Advisories (experimental):\
     [security.apache.org](/projects/apr/)
-  - Security page:\
-    [apr.apache.org](https://apr.apache.org/security_report.html)
+  - Security model:
+    - [Apache Portable Runtime (APR) security model](https://apr.apache.org/security_report.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/pulsar/default.png" alt="" loading="lazy"> **Apache Pulsar**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pulsar)
   - Advisories (experimental):\
     [security.apache.org](/projects/pulsar/)
-  - Security page:\
-    [github.com](https://github.com/apache/pulsar/security/policy)
+  - Security model:
+    - [Apache Pulsar security model](https://github.com/apache/pulsar/security/policy)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="Q">
@@ -1039,8 +1042,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ranger)
   - Advisories:\
     [cwiki.apache.org](https://cwiki.apache.org/confluence/display/RANGER/Vulnerabilities+found+in+Ranger)
-  - Security page:\
-    [github.com](https://github.com/apache/ranger/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Ranger security model](https://github.com/apache/ranger/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/ratis/default.png" alt="" loading="lazy"> **Apache Ratis**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ratis)
@@ -1051,8 +1054,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20RocketMQ)
   - Advisories (experimental):\
     [security.apache.org](/projects/rocketmq/)
-  - Security page:\
-    [rocketmq.apache.org](https://rocketmq.apache.org/docs/security/01security/)
+  - Security model:
+    - [Apache RocketMQ security model](https://rocketmq.apache.org/docs/security/01security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/roller/default.png" alt="" loading="lazy"> **Apache Roller**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Roller)
@@ -1084,8 +1087,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Santuario)
   - Advisories (experimental):\
     [security.apache.org](/projects/santuario/)
-  - Security page:\
-    [github.com](https://github.com/apache/santuario-xml-security-java/blob/main/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Santuario security model](https://github.com/apache/santuario-xml-security-java/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sdap/default.png" alt="" loading="lazy"> **Apache SDAP**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SDAP)
@@ -1096,15 +1099,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Seata)
   - Advisories (experimental):\
     [security.apache.org](/projects/seata/)
-  - Security page:\
-    [seata.apache.org](https://seata.apache.org/docs/next/security/secret-key)
+  - Security model:
+    - [Apache Seata security model](https://seata.apache.org/docs/next/security/secret-key)
 - <img class="project-logo" src="https://www.apache.org/logos/res/seatunnel/default.png" alt="" loading="lazy"> **Apache SeaTunnel**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SeaTunnel)
   - Advisories (experimental):\
     [security.apache.org](/projects/seatunnel/)
-  - Security page:\
-    [seatunnel.apache.org](https://seatunnel.apache.org/security)
+  - Security model:
+    - [Apache SeaTunnel security model](https://seatunnel.apache.org/security)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sedona/default.png" alt="" loading="lazy"> **Apache Sedona**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Sedona)
@@ -1125,29 +1128,29 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShardingSphere)
   - Advisories (experimental):\
     [security.apache.org](/projects/shardingsphere/)
-  - Security page:\
-    [shardingsphere.apache.org](https://shardingsphere.apache.org/community/en/security/)
+  - Security model:
+    - [Apache ShardingSphere security model](https://shardingsphere.apache.org/community/en/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/shenyu/default.png" alt="" loading="lazy"> **Apache ShenYu**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShenYu)
   - Advisories (experimental):\
     [security.apache.org](/projects/shenyu/)
-  - Security page:\
-    [github.com](https://github.com/apache/shenyu/blob/master/SECURITY_MODEL.md)
+  - Security model:
+    - [Apache ShenYu security model](https://github.com/apache/shenyu/blob/master/SECURITY_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/shiro/default.png" alt="" loading="lazy"> **Apache Shiro**
   - **Security contact:**\
     [security@shiro.apache.org](mailto:security@shiro.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/shiro/)
-  - Security page:\
-    [shiro.apache.org](https://shiro.apache.org/security-reports.html)
+  - Security model:
+    - [Apache Shiro security model](https://shiro.apache.org/security-reports.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/singa/default.png" alt="" loading="lazy"> **Apache SINGA**
   - **Security contact:**\
     [security@singa.apache.org](mailto:security@singa.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [singa.apache.org](https://singa.apache.org/security.html)
+  - Security model:
+    - [Apache SINGA security model](https://singa.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sis/default.png" alt="" loading="lazy"> **Apache SIS**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SIS)
@@ -1158,36 +1161,36 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SkyWalking)
   - Advisories (experimental):\
     [security.apache.org](/projects/skywalking/)
-  - Security page:\
-    [skywalking.apache.org](https://skywalking.apache.org/docs/main/next/en/security/readme/)
+  - Security model:
+    - [Apache SkyWalking security model](https://skywalking.apache.org/docs/main/next/en/security/readme/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/sling/default.png" alt="" loading="lazy"> **Apache Sling**
   - **Security contact:**\
     [security@sling.apache.org](mailto:security@sling.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/sling/)
-  - Security page:\
-    [github.com](https://github.com/apache/sling/blob/master/docs/threat-model.md)
+  - Security model:
+    - [Apache Sling security model](https://github.com/apache/sling/blob/master/docs/threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/solr/default.png" alt="" loading="lazy"> **Apache Solr**
   - **Security contact:**\
     [security@solr.apache.org](mailto:security@solr.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [solr.apache.org](https://solr.apache.org/security.html#recent-cve-reports-for-apache-solr)
-  - Security page:\
-    [cwiki.apache.org](https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity)
+  - Security model:
+    - [Apache Solr security model](https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity)
 - <img class="project-logo" src="https://www.apache.org/logos/res/spamassassin/default.png" alt="" loading="lazy"> **Apache SpamAssassin**
   - **Security contact:**\
     [security@spamassassin.apache.org](mailto:security@spamassassin.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/spamassassin/)
-  - Security page:\
-    [cwiki.apache.org](https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy)
+  - Security model:
+    - [Apache SpamAssassin security model](https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/spark/default.png" alt="" loading="lazy"> **Apache Spark**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Spark)
   - Advisories:\
     [spark.apache.org](https://spark.apache.org/security.html)
-  - Security page:\
-    [spark.apache.org](https://spark.apache.org/security.html)
+  - Security model:
+    - [Apache Spark security model](https://spark.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/steve/default.png" alt="" loading="lazy"> **Apache Steve**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Steve)
@@ -1198,57 +1201,57 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Storm)
   - Advisories (experimental):\
     [security.apache.org](/projects/storm/)
-  - Security page:\
-    [storm.apache.org](https://storm.apache.org/security-model.html)
+  - Security model:
+    - [Apache Storm security model](https://storm.apache.org/security-model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/stormcrawler/default.png" alt="" loading="lazy"> **Apache StormCrawler**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StormCrawler)
   - Advisories:\
     [stormcrawler.apache.org](https://stormcrawler.apache.org/security/)
-  - Security page:\
-    [stormcrawler.apache.org](https://stormcrawler.apache.org/security/)
+  - Security model:
+    - [Apache StormCrawler security model](https://stormcrawler.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/streampark/default.png" alt="" loading="lazy"> **Apache StreamPark**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPark)
   - Advisories (experimental):\
     [security.apache.org](/projects/streampark/)
-  - Security page:\
-    [streampark.apache.org](https://streampark.apache.org/community/security/)
+  - Security model:
+    - [Apache StreamPark security model](https://streampark.apache.org/community/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/streampipes/default.png" alt="" loading="lazy"> **Apache StreamPipes**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPipes)
   - Advisories (experimental):\
     [security.apache.org](/projects/streampipes/)
-  - Security page:\
-    [github.com](https://github.com/apache/streampipes/blob/dev/THREAT_MODEL.md)
+  - Security model:
+    - [Apache StreamPipes security model](https://github.com/apache/streampipes/blob/dev/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/struts/default.png" alt="" loading="lazy"> **Apache Struts**
   - **Security contact:**\
     [security@struts.apache.org](mailto:security@struts.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [cwiki.apache.org](https://cwiki.apache.org/confluence/display/WW/Security+Bulletins)
-  - Security page:\
-    [github.com](https://github.com/apache/struts/blob/main/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Struts security model](https://github.com/apache/struts/blob/main/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/subversion/default.png" alt="" loading="lazy"> **Apache Subversion**
   - **Security contact:**\
     [security@subversion.apache.org](mailto:security@subversion.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [subversion.apache.org](https://subversion.apache.org/security/)
-  - Security page:\
-    [subversion.apache.org](https://subversion.apache.org/security/)
+  - Security model:
+    - [Apache Subversion security model](https://subversion.apache.org/security/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/superset/default.png" alt="" loading="lazy"> **Apache Superset**
   - **Security contact:**\
     [security@superset.apache.org](mailto:security@superset.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [superset.apache.org](https://superset.apache.org/docs/security/cves)
-  - Security page:\
-    [github.com](https://github.com/apache/superset/security/policy)
+  - Security model:
+    - [Apache Superset security model](https://github.com/apache/superset/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/synapse/default.png" alt="" loading="lazy"> **Apache Synapse**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Synapse)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [github.com](https://github.com/apache/synapse/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Synapse security model](https://github.com/apache/synapse/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/syncope/default.png" alt="" loading="lazy"> **Apache Syncope**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Syncope)
@@ -1270,8 +1273,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tapestry)
   - Advisories (experimental):\
     [security.apache.org](/projects/tapestry/)
-  - Security page:\
-    [github.com](https://github.com/apache/tapestry-5/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Tapestry security model](https://github.com/apache/tapestry-5/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tcl/default.png" alt="" loading="lazy"> **Apache Tcl**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tcl)
@@ -1292,15 +1295,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Thrift)
   - Advisories (experimental):\
     [security.apache.org](/projects/thrift/)
-  - Security page:\
-    [github.com](https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md)
+  - Security model:
+    - [Apache Thrift security model](https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tika/default.png" alt="" loading="lazy"> **Apache Tika**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tika)
   - Advisories:\
     [tika.apache.org](https://tika.apache.org/security.html)
-  - Security page:\
-    [tika.apache.org](https://tika.apache.org/security-model.html)
+  - Security model:
+    - [Apache Tika security model](https://tika.apache.org/security-model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tinkerpop/default.png" alt="" loading="lazy"> **Apache TinkerPop**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20TinkerPop)
@@ -1311,8 +1314,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@tomcat.apache.org](mailto:security@tomcat.apache.org?subject=%5BFINDING%5D)
   - Advisories:\
     [tomcat.apache.org](https://tomcat.apache.org/security.html)
-  - Security page:\
-    [tomcat.apache.org](https://tomcat.apache.org/security.html)
+  - Security model:
+    - [Apache Tomcat security model](https://tomcat.apache.org/security.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/tomee/default.png" alt="" loading="lazy"> **Apache TomEE**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20TomEE)
@@ -1323,8 +1326,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@trafficserver.apache.org](mailto:security@trafficserver.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/trafficserver/)
-  - Security page:\
-    [github.com](https://github.com/apache/trafficserver/security/policy)
+  - Security model:
+    - [Apache Traffic Server security model](https://github.com/apache/trafficserver/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/training/default.png" alt="" loading="lazy"> **Apache Training**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Training)
@@ -1345,8 +1348,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20TVM)
   - Advisories (experimental):\
     none so far
-  - Security page:\
-    [tvm.apache.org](https://tvm.apache.org/docs/reference/security.html)
+  - Security model:
+    - [Apache TVM security model](https://tvm.apache.org/docs/reference/security.html)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="U">
@@ -1368,8 +1371,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Unomi)
   - Advisories (experimental):\
     [security.apache.org](/projects/unomi/)
-  - Security page:\
-    [github.com](https://github.com/apache/unomi/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Unomi security model](https://github.com/apache/unomi/blob/master/THREAT_MODEL.md)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="V">
@@ -1386,8 +1389,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Velocity)
   - Advisories (experimental):\
     [security.apache.org](/projects/velocity/)
-  - Security page:\
-    [velocity.apache.org](https://velocity.apache.org/#security-model)
+  - Security model:
+    - [Apache Velocity security model](https://velocity.apache.org/#security-model)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="W">
@@ -1435,8 +1438,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20XML%20Graphics)
   - Advisories (experimental):\
     [security.apache.org](/projects/xmlgraphics/)
-  - Security page:\
-    [xmlgraphics.apache.org](https://xmlgraphics.apache.org/security.html)
+  - Security model:
+    - [Apache XML Graphics security model](https://xmlgraphics.apache.org/security.html)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="Y">
@@ -1464,15 +1467,15 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@zeppelin.apache.org](mailto:security@zeppelin.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/zeppelin/)
-  - Security page:\
-    [github.com](https://github.com/apache/zeppelin/blob/master/THREAT_MODEL.md)
+  - Security model:
+    - [Apache Zeppelin security model](https://github.com/apache/zeppelin/blob/master/THREAT_MODEL.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/zookeeper/default.png" alt="" loading="lazy"> **Apache ZooKeeper**
   - **Security contact:**\
     [security@zookeeper.apache.org](mailto:security@zookeeper.apache.org?subject=%5BFINDING%5D)
   - Advisories (experimental):\
     [security.apache.org](/projects/zookeeper/)
-  - Security page:\
-    [zookeeper.apache.org](https://zookeeper.apache.org/security.html)
+  - Security model:
+    - [Apache ZooKeeper security model](https://zookeeper.apache.org/security.html)
 
 </section>
 </div>

--- a/content/projects/accumulo/_index.md
+++ b/content/projects/accumulo/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Accumulo? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Accumulo? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Accumulo).
 
 # Advisories
 

--- a/content/projects/accumulo/_index.md
+++ b/content/projects/accumulo/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Accumulo? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Accumulo).
+Do you want disclose a potential security issue for Apache Accumulo? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Accumulo).
 
 # Advisories
 

--- a/content/projects/activemq/_index.md
+++ b/content/projects/activemq/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ActiveMQ? You can read more about the projects' security policy on their [security page](https://github.com/apache/activemq/security/policy), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ActiveMQ? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ActiveMQ).
+
+You can read more about the security policy on:
+
+- [Apache ActiveMQ security model](https://github.com/apache/activemq/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/activemq/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Temporary destination ownership takeover ## { #CVE-2026-54475 }

--- a/content/projects/activemq/_index.md
+++ b/content/projects/activemq/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ActiveMQ? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ActiveMQ).
+Do you want disclose a potential security issue for Apache ActiveMQ? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=ActiveMQ).
 
 You can read more about the security policy on:
 

--- a/content/projects/age/_index.md
+++ b/content/projects/age/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache AGE? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache AGE? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AGE).
 
 # Advisories
 

--- a/content/projects/age/_index.md
+++ b/content/projects/age/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache AGE? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AGE).
+Do you want disclose a potential security issue for Apache AGE? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=AGE).
 
 # Advisories
 

--- a/content/projects/airavata/_index.md
+++ b/content/projects/airavata/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Airavata? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Airavata).
+Do you want disclose a potential security issue for Apache Airavata? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Airavata).
 
 # Advisories
 

--- a/content/projects/airavata/_index.md
+++ b/content/projects/airavata/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Airavata? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Airavata? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Airavata).
 
 # Advisories
 

--- a/content/projects/airflow/_index.md
+++ b/content/projects/airflow/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Airflow? You can read more about the projects' security policy on their [security page](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html), and email your report to the [Apache Airflow Security Team](mailto:security@airflow.apache.org).
+Do you want disclose a potential security issue for Apache Airflow? Send your report to the [Apache Airflow Security Team](mailto:security%40airflow.apache.org?subject=%5BFINDING%5D%20Apache%20Airflow).
+
+You can read more about the security policy on:
+
+- [Apache Airflow security model](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## FAB auth manager: a DAG named "DAGs" hijacks the global all-DAGs permission (access_control privilege escalation via resource_name() collision) ## { #CVE-2026-59245 }

--- a/content/projects/airflow/_index.md
+++ b/content/projects/airflow/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Airflow? Send your report to the [Apache Airflow Security Team](mailto:security%40airflow.apache.org?subject=%5BFINDING%5D%20Apache%20Airflow).
+Do you want disclose a potential security issue for Apache Airflow? Send your report to the [Apache Airflow Security Team](mailto:security@airflow.apache.org?subject=Airflow).
 
 You can read more about the security policy on:
 

--- a/content/projects/allura/_index.md
+++ b/content/projects/allura/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Allura? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Allura).
+Do you want disclose a potential security issue for Apache Allura? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Allura).
 
 # Advisories
 

--- a/content/projects/allura/_index.md
+++ b/content/projects/allura/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Allura? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Allura? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Allura).
 
 # Advisories
 

--- a/content/projects/ambari/_index.md
+++ b/content/projects/ambari/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ambari? Send your report to the [Apache Ambari Security Team](mailto:security%40ambari.apache.org?subject=%5BFINDING%5D%20Apache%20Ambari).
+Do you want disclose a potential security issue for Apache Ambari? Send your report to the [Apache Ambari Security Team](mailto:security@ambari.apache.org?subject=Ambari).
 
 # Advisories
 

--- a/content/projects/ambari/_index.md
+++ b/content/projects/ambari/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ambari? Send your report to the [Apache Ambari Security Team](mailto:security@ambari.apache.org).
+Do you want disclose a potential security issue for Apache Ambari? Send your report to the [Apache Ambari Security Team](mailto:security%40ambari.apache.org?subject=%5BFINDING%5D%20Apache%20Ambari).
 
 # Advisories
 

--- a/content/projects/answer/_index.md
+++ b/content/projects/answer/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Answer? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Answer).
+Do you want disclose a potential security issue for Apache Answer? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Answer).
 
 You can read more about the security policy on:
 

--- a/content/projects/answer/_index.md
+++ b/content/projects/answer/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Answer? You can read more about the projects' security policy on their [security page](https://answer.apache.org/community/security-model), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Answer? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Answer).
+
+You can read more about the security policy on:
+
+- [Apache Answer security model](https://answer.apache.org/community/security-model)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://answer.apache.org/community/security-model). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Unlisted Questions Accessible via Direct API Access ## { #CVE-2026-34905 }

--- a/content/projects/ant/_index.md
+++ b/content/projects/ant/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ant? You can read more about the projects' security policy on their [security page](https://ant.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Ant? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ant).
+
+You can read more about the security policy on:
+
+- [Apache Ant security model](https://ant.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://ant.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## PackagerResolver path traversal vulnerability ## { #CVE-2026-26032 }

--- a/content/projects/ant/_index.md
+++ b/content/projects/ant/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ant? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ant).
+Do you want disclose a potential security issue for Apache Ant? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Ant).
 
 You can read more about the security policy on:
 

--- a/content/projects/any23/_index.md
+++ b/content/projects/any23/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Any23? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Any23).
+Do you want disclose a potential security issue for Apache Any23? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Any23).
 
 # Advisories
 

--- a/content/projects/any23/_index.md
+++ b/content/projects/any23/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Any23? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Any23? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Any23).
 
 # Advisories
 

--- a/content/projects/apisix/_index.md
+++ b/content/projects/apisix/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache APISIX? You can read more about the projects' security policy on their [security page](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache APISIX? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20APISIX).
+
+You can read more about the security policy on:
+
+- [Apache APISIX security model](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/apisix/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Improper authentication in cas-auth plugin ## { #CVE-2026-49872 }

--- a/content/projects/apisix/_index.md
+++ b/content/projects/apisix/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache APISIX? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20APISIX).
+Do you want disclose a potential security issue for Apache APISIX? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=APISIX).
 
 You can read more about the security policy on:
 

--- a/content/projects/apr/_index.md
+++ b/content/projects/apr/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Portable Runtime (APR)? You can read more about the projects' security policy on their [security page](https://apr.apache.org/security_report.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Portable Runtime (APR)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Portable%20Runtime%20%28APR%29).
+
+You can read more about the security policy on:
+
+- [Apache Portable Runtime (APR) security model](https://apr.apache.org/security_report.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://apr.apache.org/security_report.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Unexpected lax shared memory permissions ## { #CVE-2023-49582 }

--- a/content/projects/apr/_index.md
+++ b/content/projects/apr/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Portable Runtime (APR)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Portable%20Runtime%20%28APR%29).
+Do you want disclose a potential security issue for Apache Portable Runtime (APR)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Portable%20Runtime%20%28APR%29).
 
 You can read more about the security policy on:
 

--- a/content/projects/archiva/_index.md
+++ b/content/projects/archiva/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Archiva? You can read more about the projects' security policy on their [security page](https://archiva.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Archiva? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Archiva).
+
+You can read more about the security policy on:
+
+- [Apache Archiva security model](https://archiva.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://archiva.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## reflected XSS ## { #CVE-2024-27140 }

--- a/content/projects/archiva/_index.md
+++ b/content/projects/archiva/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Archiva? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Archiva).
+Do you want disclose a potential security issue for Apache Archiva? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Archiva).
 
 You can read more about the security policy on:
 

--- a/content/projects/arrow/_index.md
+++ b/content/projects/arrow/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Arrow? You can read more about the projects' security policy on their [security page](https://arrow.apache.org/docs/dev/format/Security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Arrow? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Arrow).
+
+You can read more about the security policy on:
+
+- [Apache Arrow security model](https://arrow.apache.org/docs/dev/format/Security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://arrow.apache.org/docs/dev/format/Security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Potential use-after-free when reading IPC file with pre-buffering ## { #CVE-2026-25087 }

--- a/content/projects/arrow/_index.md
+++ b/content/projects/arrow/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Arrow? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Arrow).
+Do you want disclose a potential security issue for Apache Arrow? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Arrow).
 
 You can read more about the security policy on:
 

--- a/content/projects/artemis/_index.md
+++ b/content/projects/artemis/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Artemis? You can read more about the projects' security policy on their [security page](https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Artemis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Artemis).
+
+You can read more about the security policy on:
+
+- [Apache Artemis security model](https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Address routing-type can be updated by STOMP protocol user without the createAddress permission ## { #CVE-2026-40914 }

--- a/content/projects/artemis/_index.md
+++ b/content/projects/artemis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Artemis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Artemis).
+Do you want disclose a potential security issue for Apache Artemis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Artemis).
 
 You can read more about the security policy on:
 

--- a/content/projects/asterixdb/_index.md
+++ b/content/projects/asterixdb/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache AsterixDB? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache AsterixDB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AsterixDB).
 
 # Advisories
 

--- a/content/projects/asterixdb/_index.md
+++ b/content/projects/asterixdb/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache AsterixDB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20AsterixDB).
+Do you want disclose a potential security issue for Apache AsterixDB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=AsterixDB).
 
 # Advisories
 

--- a/content/projects/atlas/_index.md
+++ b/content/projects/atlas/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Atlas? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Atlas? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Atlas).
 
 # Advisories
 

--- a/content/projects/atlas/_index.md
+++ b/content/projects/atlas/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Atlas? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Atlas).
+Do you want disclose a potential security issue for Apache Atlas? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Atlas).
 
 # Advisories
 

--- a/content/projects/aurora/_index.md
+++ b/content/projects/aurora/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Aurora? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Aurora).
+Do you want disclose a potential security issue for Apache Aurora? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Aurora).
 
 # Advisories
 

--- a/content/projects/aurora/_index.md
+++ b/content/projects/aurora/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Aurora? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Aurora? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Aurora).
 
 # Advisories
 

--- a/content/projects/avro/_index.md
+++ b/content/projects/avro/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Avro? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Avro).
+Do you want disclose a potential security issue for Apache Avro? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Avro).
 
 You can read more about the security policy on:
 

--- a/content/projects/avro/_index.md
+++ b/content/projects/avro/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Avro? You can read more about the projects' security policy on their [security page](https://avro.apache.org/project/security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Avro? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Avro).
+
+You can read more about the security policy on:
+
+- [Apache Avro security model](https://avro.apache.org/project/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://avro.apache.org/project/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Code injection on Java generated code ## { #CVE-2025-33042 }

--- a/content/projects/axis/_index.md
+++ b/content/projects/axis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Axis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Axis).
+Do you want disclose a potential security issue for Apache Axis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Axis).
 
 You can read more about the security policy on:
 

--- a/content/projects/axis/_index.md
+++ b/content/projects/axis/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Axis? You can read more about the projects' security policy on their [security page](https://github.com/apache/axis-axis2-java-core/security/policy), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Axis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Axis).
+
+You can read more about the security policy on:
+
+- [Apache Axis security model](https://github.com/apache/axis-axis2-java-core/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/axis-axis2-java-core/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Apache Axis 1.x (EOL) may allow SSRF when untrusted input is passed to the service admin HTTP API ## { #CVE-2023-51441 }

--- a/content/projects/bookkeeper/_index.md
+++ b/content/projects/bookkeeper/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache BookKeeper? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache BookKeeper? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20BookKeeper).
 
 # Advisories
 

--- a/content/projects/bookkeeper/_index.md
+++ b/content/projects/bookkeeper/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache BookKeeper? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20BookKeeper).
+Do you want disclose a potential security issue for Apache BookKeeper? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=BookKeeper).
 
 # Advisories
 

--- a/content/projects/brpc/_index.md
+++ b/content/projects/brpc/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache bRPC? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20bRPC).
+Do you want disclose a potential security issue for Apache bRPC? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=bRPC).
 
 You can read more about the security policy on:
 

--- a/content/projects/brpc/_index.md
+++ b/content/projects/brpc/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache bRPC? You can read more about the projects' security policy on their [security page](https://github.com/apache/brpc/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache bRPC? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20bRPC).
+
+You can read more about the security policy on:
+
+- [Apache bRPC security model](https://github.com/apache/brpc/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/brpc/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Remote command injection vulnerability in heap builtin service ## { #CVE-2025-60021 }

--- a/content/projects/calcite/_index.md
+++ b/content/projects/calcite/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Calcite? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Calcite? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Calcite).
 
 # Advisories
 

--- a/content/projects/calcite/_index.md
+++ b/content/projects/calcite/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Calcite? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Calcite).
+Do you want disclose a potential security issue for Apache Calcite? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Calcite).
 
 # Advisories
 

--- a/content/projects/camel/_index.md
+++ b/content/projects/camel/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Camel? You can read more about the projects' security policy on their [security page](https://camel.apache.org/manual/security-model.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Camel? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Camel).
+
+You can read more about the security policy on:
+
+- [Apache Camel security model](https://camel.apache.org/manual/security-model.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://camel.apache.org/manual/security-model.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## An inbound Camel-namespace filter was added to Sns2HeaderFilterStrategy to align it with sibling components ## { #CVE-2026-56140 }

--- a/content/projects/camel/_index.md
+++ b/content/projects/camel/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Camel? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Camel).
+Do you want disclose a potential security issue for Apache Camel? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Camel).
 
 You can read more about the security policy on:
 

--- a/content/projects/cassandra/_index.md
+++ b/content/projects/cassandra/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cassandra? You can read more about the projects' security policy on their [security page](https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Cassandra? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cassandra).
+
+You can read more about the security policy on:
+
+- [Apache Cassandra security model](https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Authenticated DoS via ALTER ROLE Password Hashing ## { #CVE-2026-32588 }

--- a/content/projects/cassandra/_index.md
+++ b/content/projects/cassandra/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cassandra? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cassandra).
+Do you want disclose a potential security issue for Apache Cassandra? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Cassandra).
 
 You can read more about the security policy on:
 

--- a/content/projects/causeway/_index.md
+++ b/content/projects/causeway/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Causeway? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Causeway).
+Do you want disclose a potential security issue for Apache Causeway? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Causeway).
 
 # Advisories
 

--- a/content/projects/causeway/_index.md
+++ b/content/projects/causeway/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Causeway? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Causeway? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Causeway).
 
 # Advisories
 

--- a/content/projects/cayenne/_index.md
+++ b/content/projects/cayenne/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cayenne? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cayenne).
+Do you want disclose a potential security issue for Apache Cayenne? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Cayenne).
 
 # Advisories
 

--- a/content/projects/cayenne/_index.md
+++ b/content/projects/cayenne/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cayenne? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Cayenne? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cayenne).
 
 # Advisories
 

--- a/content/projects/cloudstack/_index.md
+++ b/content/projects/cloudstack/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache CloudStack? You can read more about the projects' security policy on their [security page](https://github.com/apache/cloudstack/blob/main/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache CloudStack? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CloudStack).
+
+You can read more about the security policy on:
+
+- [Apache CloudStack security model](https://github.com/apache/cloudstack/blob/main/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/cloudstack/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Proxmox Extension Allows Unauthorized Cross-Tenant Instance Access ## { #CVE-2026-25199 }

--- a/content/projects/cloudstack/_index.md
+++ b/content/projects/cloudstack/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache CloudStack? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CloudStack).
+Do you want disclose a potential security issue for Apache CloudStack? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=CloudStack).
 
 You can read more about the security policy on:
 

--- a/content/projects/cocoon/_index.md
+++ b/content/projects/cocoon/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cocoon? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Cocoon? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cocoon).
 
 # Advisories
 

--- a/content/projects/cocoon/_index.md
+++ b/content/projects/cocoon/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cocoon? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cocoon).
+Do you want disclose a potential security issue for Apache Cocoon? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Cocoon).
 
 # Advisories
 

--- a/content/projects/commons/_index.md
+++ b/content/projects/commons/_index.md
@@ -6,11 +6,19 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Commons? You can read more about the projects' security policy on their [security page](https://commons.apache.org/security.html), and email your report to the [Apache Commons Security Team](mailto:security@commons.apache.org).
+Do you want disclose a potential security issue for Apache Commons? Send your report to the [Apache Commons Security Team](mailto:security%40commons.apache.org?subject=%5BFINDING%5D%20Apache%20Commons).
+
+You can read more about the security policy on:
+
+- [Apache Commons security model](https://commons.apache.org/threat_model.html)
+- [Apache Commons Configuration security model](https://commons.apache.org/proper/commons-configuration/security.html)
+- [Apache Commons Imaging security model](https://commons.apache.org/proper/commons-imaging/security.html)
+- [Apache Commons XML security model](https://commons.apache.org/sandbox/commons-xml/threat_model.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://commons.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security pages linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## StackOverflowError for YAML input with cycles ## { #CVE-2026-45205 }

--- a/content/projects/commons/_index.md
+++ b/content/projects/commons/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Commons? Send your report to the [Apache Commons Security Team](mailto:security%40commons.apache.org?subject=%5BFINDING%5D%20Apache%20Commons).
+Do you want disclose a potential security issue for Apache Commons? Send your report to the [Apache Commons Security Team](mailto:security@commons.apache.org?subject=Commons).
 
 You can read more about the security policy on:
 

--- a/content/projects/continuum/_index.md
+++ b/content/projects/continuum/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Continuum? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Continuum).
+Do you want disclose a potential security issue for Apache Continuum? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Continuum).
 
 # Advisories
 

--- a/content/projects/continuum/_index.md
+++ b/content/projects/continuum/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Continuum? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Continuum? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Continuum).
 
 # Advisories
 

--- a/content/projects/cordova/_index.md
+++ b/content/projects/cordova/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cordova? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Cordova? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cordova).
 
 # Advisories
 

--- a/content/projects/cordova/_index.md
+++ b/content/projects/cordova/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Cordova? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Cordova).
+Do you want disclose a potential security issue for Apache Cordova? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Cordova).
 
 # Advisories
 

--- a/content/projects/couchdb/_index.md
+++ b/content/projects/couchdb/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache CouchDB? Send your report to the [Apache CouchDB Security Team](mailto:security@couchdb.apache.org).
+Do you want disclose a potential security issue for Apache CouchDB? Send your report to the [Apache CouchDB Security Team](mailto:security%40couchdb.apache.org?subject=%5BFINDING%5D%20Apache%20CouchDB).
 
 # Advisories
 

--- a/content/projects/couchdb/_index.md
+++ b/content/projects/couchdb/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache CouchDB? Send your report to the [Apache CouchDB Security Team](mailto:security%40couchdb.apache.org?subject=%5BFINDING%5D%20Apache%20CouchDB).
+Do you want disclose a potential security issue for Apache CouchDB? Send your report to the [Apache CouchDB Security Team](mailto:security@couchdb.apache.org?subject=CouchDB).
 
 # Advisories
 

--- a/content/projects/cxf/_index.md
+++ b/content/projects/cxf/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache CXF? You can read more about the projects' security policy on their [security page](https://github.com/apache/cxf/blob/main/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache CXF? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CXF).
+
+You can read more about the security policy on:
+
+- [Apache CXF security model](https://github.com/apache/cxf/blob/main/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/cxf/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## No restriction on attachment headers per message ## { #CVE-2026-50645 }

--- a/content/projects/cxf/_index.md
+++ b/content/projects/cxf/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache CXF? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20CXF).
+Do you want disclose a potential security issue for Apache CXF? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=CXF).
 
 You can read more about the security policy on:
 

--- a/content/projects/db/_index.md
+++ b/content/projects/db/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache DB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DB).
+Do you want disclose a potential security issue for Apache DB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=DB).
 
 You can read more about the security policy on:
 

--- a/content/projects/db/_index.md
+++ b/content/projects/db/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache DB? You can read more about the projects' security policy on their [security page](https://github.com/apache/db-jdo/blob/main/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache DB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20DB).
+
+You can read more about the security policy on:
+
+- [Apache DB security model](https://github.com/apache/db-jdo/blob/main/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/db-jdo/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## LDAP injection vulnerability in authenticator ## { #CVE-2022-46337 }

--- a/content/projects/directory/_index.md
+++ b/content/projects/directory/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Directory? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Directory).
+Do you want disclose a potential security issue for Apache Directory? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Directory).
 
 You can read more about the security policy on:
 

--- a/content/projects/directory/_index.md
+++ b/content/projects/directory/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Directory? You can read more about the projects' security policy on their [security page](https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Directory? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Directory).
+
+You can read more about the security policy on:
+
+- [Apache Directory security model](https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Kerberos Pre-Authentication Bypass ## { #CVE-2026-57915 }

--- a/content/projects/dolphinscheduler/_index.md
+++ b/content/projects/dolphinscheduler/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache DolphinScheduler? You can read more about the projects' security policy on their [security page](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md), and email your report to the [Apache DolphinScheduler Security Team](mailto:security@dolphinscheduler.apache.org).
+Do you want disclose a potential security issue for Apache DolphinScheduler? Send your report to the [Apache DolphinScheduler Security Team](mailto:security%40dolphinscheduler.apache.org?subject=%5BFINDING%5D%20Apache%20DolphinScheduler).
+
+You can read more about the security policy on:
+
+- [Apache DolphinScheduler security model](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## General user can mint admin access tokens via /access-tokens ## { #CVE-2026-49050 }

--- a/content/projects/dolphinscheduler/_index.md
+++ b/content/projects/dolphinscheduler/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache DolphinScheduler? Send your report to the [Apache DolphinScheduler Security Team](mailto:security%40dolphinscheduler.apache.org?subject=%5BFINDING%5D%20Apache%20DolphinScheduler).
+Do you want disclose a potential security issue for Apache DolphinScheduler? Send your report to the [Apache DolphinScheduler Security Team](mailto:security@dolphinscheduler.apache.org?subject=DolphinScheduler).
 
 You can read more about the security policy on:
 

--- a/content/projects/doris/_index.md
+++ b/content/projects/doris/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Doris? You can read more about the projects' security policy on their [security page](https://github.com/apache/doris/blob/master/threat-model.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Doris? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Doris).
+
+You can read more about the security policy on:
+
+- [Apache Doris security model](https://github.com/apache/doris/blob/master/threat-model.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/doris/blob/master/threat-model.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Improper Authentication in Frontend HTTP API ## { #CVE-2026-58319 }

--- a/content/projects/doris/_index.md
+++ b/content/projects/doris/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Doris? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Doris).
+Do you want disclose a potential security issue for Apache Doris? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Doris).
 
 You can read more about the security policy on:
 

--- a/content/projects/drill/_index.md
+++ b/content/projects/drill/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Drill? You can read more about the projects' security policy on their [security page](https://github.com/apache/drill/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Drill? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Drill).
+
+You can read more about the security policy on:
+
+- [Apache Drill security model](https://github.com/apache/drill/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/drill/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## XXE Vulnerability in XML Format Reader ## { #CVE-2023-48362 }

--- a/content/projects/drill/_index.md
+++ b/content/projects/drill/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Drill? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Drill).
+Do you want disclose a potential security issue for Apache Drill? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Drill).
 
 You can read more about the security policy on:
 

--- a/content/projects/druid/_index.md
+++ b/content/projects/druid/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Druid? You can read more about the projects' security policy on their [security page](https://druid.apache.org/docs/latest/operations/security-overview.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Druid? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Druid).
+
+You can read more about the security policy on:
+
+- [Apache Druid security model](https://druid.apache.org/docs/latest/operations/security-overview.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://druid.apache.org/docs/latest/operations/security-overview.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Authentication Bypass via LDAP Anonymous Bind ## { #CVE-2026-23906 }

--- a/content/projects/druid/_index.md
+++ b/content/projects/druid/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Druid? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Druid).
+Do you want disclose a potential security issue for Apache Druid? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Druid).
 
 You can read more about the security policy on:
 

--- a/content/projects/dubbo/_index.md
+++ b/content/projects/dubbo/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Dubbo? You can read more about the projects' security policy on their [security page](https://github.com/apache/dubbo/blob/3.3/docs/threat-model.md), and email your report to the [Apache Dubbo Security Team](mailto:security@dubbo.apache.org).
+Do you want disclose a potential security issue for Apache Dubbo? Send your report to the [Apache Dubbo Security Team](mailto:security%40dubbo.apache.org?subject=%5BFINDING%5D%20Apache%20Dubbo).
+
+You can read more about the security policy on:
+
+- [Apache Dubbo security model](https://github.com/apache/dubbo/blob/3.3/docs/threat-model.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/dubbo/blob/3.3/docs/threat-model.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Bypass deny serialize list check in Apache Dubbo ## { #CVE-2023-46279 }

--- a/content/projects/dubbo/_index.md
+++ b/content/projects/dubbo/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Dubbo? Send your report to the [Apache Dubbo Security Team](mailto:security%40dubbo.apache.org?subject=%5BFINDING%5D%20Apache%20Dubbo).
+Do you want disclose a potential security issue for Apache Dubbo? Send your report to the [Apache Dubbo Security Team](mailto:security@dubbo.apache.org?subject=Dubbo).
 
 You can read more about the security policy on:
 

--- a/content/projects/echarts/_index.md
+++ b/content/projects/echarts/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ECharts? You can read more about the projects' security policy on their [security page](https://echarts.apache.org/handbook/en/best-practices/security/#), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ECharts? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ECharts).
+
+You can read more about the security policy on:
+
+- [Apache ECharts security model](https://echarts.apache.org/handbook/en/best-practices/security/#)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://echarts.apache.org/handbook/en/best-practices/security/#). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## XSS in Lines series tooltip rendering ## { #CVE-2026-45249 }

--- a/content/projects/echarts/_index.md
+++ b/content/projects/echarts/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ECharts? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ECharts).
+Do you want disclose a potential security issue for Apache ECharts? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=ECharts).
 
 You can read more about the security policy on:
 

--- a/content/projects/eventmesh/_index.md
+++ b/content/projects/eventmesh/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache EventMesh? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20EventMesh).
+Do you want disclose a potential security issue for Apache EventMesh? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=EventMesh).
 
 # Advisories
 

--- a/content/projects/eventmesh/_index.md
+++ b/content/projects/eventmesh/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache EventMesh? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache EventMesh? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20EventMesh).
 
 # Advisories
 

--- a/content/projects/felix/_index.md
+++ b/content/projects/felix/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Felix? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Felix? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Felix).
 
 # Advisories
 

--- a/content/projects/felix/_index.md
+++ b/content/projects/felix/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Felix? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Felix).
+Do you want disclose a potential security issue for Apache Felix? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Felix).
 
 # Advisories
 

--- a/content/projects/fesod/_index.md
+++ b/content/projects/fesod/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fesod (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Fesod (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fesod%20%28Incubating%29).
 
 # Advisories
 

--- a/content/projects/fesod/_index.md
+++ b/content/projects/fesod/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fesod (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fesod%20%28Incubating%29).
+Do you want disclose a potential security issue for Apache Fesod (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Fesod%20%28Incubating%29).
 
 # Advisories
 

--- a/content/projects/fineract/_index.md
+++ b/content/projects/fineract/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fineract? You can read more about the projects' security policy on their [security page](https://github.com/apache/fineract/security/policy), and email your report to the [Apache Fineract Security Team](mailto:security@fineract.apache.org).
+Do you want disclose a potential security issue for Apache Fineract? Send your report to the [Apache Fineract Security Team](mailto:security%40fineract.apache.org?subject=%5BFINDING%5D%20Apache%20Fineract).
+
+You can read more about the security policy on:
+
+- [Apache Fineract security model](https://github.com/apache/fineract/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/fineract/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Office list: SQL Injection via Subquery in orderBy ## { #CVE-2026-57821 }

--- a/content/projects/fineract/_index.md
+++ b/content/projects/fineract/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fineract? Send your report to the [Apache Fineract Security Team](mailto:security%40fineract.apache.org?subject=%5BFINDING%5D%20Apache%20Fineract).
+Do you want disclose a potential security issue for Apache Fineract? Send your report to the [Apache Fineract Security Team](mailto:security@fineract.apache.org?subject=Fineract).
 
 You can read more about the security policy on:
 

--- a/content/projects/flink/_index.md
+++ b/content/projects/flink/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Flink? You can read more about the projects' security policy on their [security page](https://flink.apache.org/what-is-flink/security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Flink? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flink).
+
+You can read more about the security policy on:
+
+- [Apache Flink security model](https://flink.apache.org/what-is-flink/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://flink.apache.org/what-is-flink/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Server-Side Request Forgery and local file access in Kubernetes Operator ## { #CVE-2026-40564 }

--- a/content/projects/flink/_index.md
+++ b/content/projects/flink/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Flink? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flink).
+Do you want disclose a potential security issue for Apache Flink? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Flink).
 
 You can read more about the security policy on:
 

--- a/content/projects/flume/_index.md
+++ b/content/projects/flume/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Flume? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flume).
+Do you want disclose a potential security issue for Apache Flume? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Flume).
 
 # Advisories
 

--- a/content/projects/flume/_index.md
+++ b/content/projects/flume/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Flume? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Flume? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Flume).
 
 # Advisories
 

--- a/content/projects/fluss/_index.md
+++ b/content/projects/fluss/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fluss (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fluss%20%28Incubating%29).
+Do you want disclose a potential security issue for Apache Fluss (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Fluss%20%28Incubating%29).
 
 # Advisories
 

--- a/content/projects/fluss/_index.md
+++ b/content/projects/fluss/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fluss (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Fluss (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fluss%20%28Incubating%29).
 
 # Advisories
 

--- a/content/projects/fory/_index.md
+++ b/content/projects/fory/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fory? You can read more about the projects' security policy on their [security page](https://github.com/apache/fory/blob/main/docs/security/threat-model.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Fory? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fory).
+
+You can read more about the security policy on:
+
+- [Apache Fory security model](https://github.com/apache/fory/blob/main/docs/security/threat-model.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/fory/blob/main/docs/security/threat-model.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Java ReplaceResolverSerializer deserialization checks bypass ## { #CVE-2026-50076 }

--- a/content/projects/fory/_index.md
+++ b/content/projects/fory/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fory? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Fory).
+Do you want disclose a potential security issue for Apache Fory? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Fory).
 
 You can read more about the security policy on:
 

--- a/content/projects/geode/_index.md
+++ b/content/projects/geode/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Geode? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Geode).
+Do you want disclose a potential security issue for Apache Geode? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Geode).
 
 You can read more about the security policy on:
 

--- a/content/projects/geode/_index.md
+++ b/content/projects/geode/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Geode? You can read more about the projects' security policy on their [security page](https://geode.apache.org/docs/guide/20/security/security_model.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Geode? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Geode).
+
+You can read more about the security policy on:
+
+- [Apache Geode security model](https://geode.apache.org/docs/guide/20/security/security_model.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://geode.apache.org/docs/guide/20/security/security_model.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## CSRF attacks through GET requests to the Management and Monitoring REST API that can execute gfsh commands on the target system ## { #CVE-2025-47410 }

--- a/content/projects/gobblin/_index.md
+++ b/content/projects/gobblin/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Gobblin? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gobblin).
+Do you want disclose a potential security issue for Apache Gobblin? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Gobblin).
 
 # Advisories
 

--- a/content/projects/gobblin/_index.md
+++ b/content/projects/gobblin/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Gobblin? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Gobblin? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gobblin).
 
 # Advisories
 

--- a/content/projects/gravitino/_index.md
+++ b/content/projects/gravitino/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Gravitino? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gravitino).
+Do you want disclose a potential security issue for Apache Gravitino? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Gravitino).
 
 # Advisories
 

--- a/content/projects/gravitino/_index.md
+++ b/content/projects/gravitino/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Gravitino? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Gravitino? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Gravitino).
 
 # Advisories
 

--- a/content/projects/guacamole/_index.md
+++ b/content/projects/guacamole/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Guacamole? Send your report to the [Apache Guacamole Security Team](mailto:security%40guacamole.apache.org?subject=%5BFINDING%5D%20Apache%20Guacamole).
+Do you want disclose a potential security issue for Apache Guacamole? Send your report to the [Apache Guacamole Security Team](mailto:security@guacamole.apache.org?subject=Guacamole).
 
 You can read more about the security policy on:
 

--- a/content/projects/guacamole/_index.md
+++ b/content/projects/guacamole/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Guacamole? You can read more about the projects' security policy on their [security page](https://guacamole.apache.org/security/), and email your report to the [Apache Guacamole Security Team](mailto:security@guacamole.apache.org).
+Do you want disclose a potential security issue for Apache Guacamole? Send your report to the [Apache Guacamole Security Team](mailto:security%40guacamole.apache.org?subject=%5BFINDING%5D%20Apache%20Guacamole).
+
+You can read more about the security policy on:
+
+- [Apache Guacamole security model](https://guacamole.apache.org/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://guacamole.apache.org/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Improper input validation of console codes ## { #CVE-2024-35164 }

--- a/content/projects/hadoop/_index.md
+++ b/content/projects/hadoop/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hadoop? Send your report to the [Apache Hadoop Security Team](mailto:security%40hadoop.apache.org?subject=%5BFINDING%5D%20Apache%20Hadoop).
+Do you want disclose a potential security issue for Apache Hadoop? Send your report to the [Apache Hadoop Security Team](mailto:security@hadoop.apache.org?subject=Hadoop).
 
 You can read more about the security policy on:
 

--- a/content/projects/hadoop/_index.md
+++ b/content/projects/hadoop/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hadoop? You can read more about the projects' security policy on their [security page](https://github.com/apache/hadoop/security/policy), and email your report to the [Apache Hadoop Security Team](mailto:security@hadoop.apache.org).
+Do you want disclose a potential security issue for Apache Hadoop? Send your report to the [Apache Hadoop Security Team](mailto:security%40hadoop.apache.org?subject=%5BFINDING%5D%20Apache%20Hadoop).
+
+You can read more about the security policy on:
+
+- [Apache Hadoop security model](https://github.com/apache/hadoop/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/hadoop/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Out of bounds write in URI parser of native HDFS client ## { #CVE-2025-27821 }

--- a/content/projects/hama/_index.md
+++ b/content/projects/hama/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hama? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Hama? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hama).
 
 # Advisories
 

--- a/content/projects/hama/_index.md
+++ b/content/projects/hama/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hama? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hama).
+Do you want disclose a potential security issue for Apache Hama? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Hama).
 
 # Advisories
 

--- a/content/projects/helix/_index.md
+++ b/content/projects/helix/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Helix? You can read more about the projects' security policy on their [security page](https://github.com/apache/helix/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Helix? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Helix).
+
+You can read more about the security policy on:
+
+- [Apache Helix security model](https://github.com/apache/helix/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/helix/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Permissive CORS Configuration in REST API Allows Unrestricted Cross-Origin ## { #CVE-2026-57111 }

--- a/content/projects/helix/_index.md
+++ b/content/projects/helix/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Helix? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Helix).
+Do you want disclose a potential security issue for Apache Helix? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Helix).
 
 You can read more about the security policy on:
 

--- a/content/projects/heron/_index.md
+++ b/content/projects/heron/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Heron (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Heron%20%28Incubating%29).
+Do you want disclose a potential security issue for Apache Heron (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Heron%20%28Incubating%29).
 
 # Advisories
 

--- a/content/projects/heron/_index.md
+++ b/content/projects/heron/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Heron (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Heron (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Heron%20%28Incubating%29).
 
 # Advisories
 

--- a/content/projects/hertzbeat/_index.md
+++ b/content/projects/hertzbeat/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hertzbeat? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hertzbeat).
+Do you want disclose a potential security issue for Apache Hertzbeat? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Hertzbeat).
 
 You can read more about the security policy on:
 

--- a/content/projects/hertzbeat/_index.md
+++ b/content/projects/hertzbeat/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hertzbeat? You can read more about the projects' security policy on their [security page](https://hertzbeat.apache.org/docs/help/security_model/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Hertzbeat? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hertzbeat).
+
+You can read more about the security policy on:
+
+- [Apache Hertzbeat security model](https://hertzbeat.apache.org/docs/help/security_model/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://hertzbeat.apache.org/docs/help/security_model/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Uncontrolled Resource Consumption via Crafted XPath Expressions ## { #CVE-2026-24343 }

--- a/content/projects/hive/_index.md
+++ b/content/projects/hive/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hive? Send your report to the [Apache Hive Security Team](mailto:security%40hive.apache.org?subject=%5BFINDING%5D%20Apache%20Hive).
+Do you want disclose a potential security issue for Apache Hive? Send your report to the [Apache Hive Security Team](mailto:security@hive.apache.org?subject=Hive).
 
 You can read more about the security policy on:
 

--- a/content/projects/hive/_index.md
+++ b/content/projects/hive/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hive? You can read more about the projects' security policy on their [security page](https://github.com/apache/hive/blob/master/THREAT_MODEL.md), and email your report to the [Apache Hive Security Team](mailto:security@hive.apache.org).
+Do you want disclose a potential security issue for Apache Hive? Send your report to the [Apache Hive Security Team](mailto:security%40hive.apache.org?subject=%5BFINDING%5D%20Apache%20Hive).
+
+You can read more about the security policy on:
+
+- [Apache Hive security model](https://github.com/apache/hive/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/hive/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## SQL injection vulnerability when processing delete column statistics requests via the HMS Thrift APIs ## { #CVE-2025-62728 }

--- a/content/projects/hop/_index.md
+++ b/content/projects/hop/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hop? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hop).
+Do you want disclose a potential security issue for Apache Hop? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Hop).
 
 You can read more about the security policy on:
 

--- a/content/projects/hop/_index.md
+++ b/content/projects/hop/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Hop? You can read more about the projects' security policy on their [security page](https://github.com/apache/hop/blob/main/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Hop? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Hop).
+
+You can read more about the security policy on:
+
+- [Apache Hop security model](https://github.com/apache/hop/blob/main/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/hop/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## ID isn't escaped when generating HTML ## { #CVE-2024-24683 }

--- a/content/projects/httpcomponents/_index.md
+++ b/content/projects/httpcomponents/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HttpComponents? You can read more about the projects' security policy on their [security page](https://hc.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache HttpComponents? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20HttpComponents).
+
+You can read more about the security policy on:
+
+- [Apache HttpComponents security model](https://hc.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://hc.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## HPackDecoder Unlimited Header List Size Before SETTINGS ACK ## { #CVE-2026-54428 }

--- a/content/projects/httpcomponents/_index.md
+++ b/content/projects/httpcomponents/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HttpComponents? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20HttpComponents).
+Do you want disclose a potential security issue for Apache HttpComponents? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=HttpComponents).
 
 You can read more about the security policy on:
 

--- a/content/projects/httpd/_index.md
+++ b/content/projects/httpd/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HTTP Server? You can read more about the projects' security policy on their [security page](https://github.com/apache/httpd/security/policy), and email your report to the [Apache HTTP Server Security Team](mailto:security@httpd.apache.org).
+Do you want disclose a potential security issue for Apache HTTP Server? Send your report to the [Apache HTTP Server Security Team](mailto:security%40httpd.apache.org?subject=%5BFINDING%5D%20Apache%20HTTP%20Server).
+
+You can read more about the security policy on:
+
+- [Apache HTTP Server security model](https://github.com/apache/httpd/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/httpd/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## mod_http2 denial of service ## { #CVE-2026-49975 }

--- a/content/projects/httpd/_index.md
+++ b/content/projects/httpd/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HTTP Server? Send your report to the [Apache HTTP Server Security Team](mailto:security%40httpd.apache.org?subject=%5BFINDING%5D%20Apache%20HTTP%20Server).
+Do you want disclose a potential security issue for Apache HTTP Server? Send your report to the [Apache HTTP Server Security Team](mailto:security@httpd.apache.org?subject=HTTP%20Server).
 
 You can read more about the security policy on:
 

--- a/content/projects/hugegraph/_index.md
+++ b/content/projects/hugegraph/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HugeGraph? You can read more about the projects' security policy on their [security page](https://hugegraph.apache.org/docs/guides/security), and email your report to the [Apache HugeGraph Security Team](mailto:security@hugegraph.apache.org).
+Do you want disclose a potential security issue for Apache HugeGraph? Send your report to the [Apache HugeGraph Security Team](mailto:security%40hugegraph.apache.org?subject=%5BFINDING%5D%20Apache%20HugeGraph).
+
+You can read more about the security policy on:
+
+- [Apache HugeGraph security model](https://hugegraph.apache.org/docs/guides/security)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://hugegraph.apache.org/docs/guides/security). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## RAFT and deserialization vulnerability ## { #CVE-2025-26866 }

--- a/content/projects/hugegraph/_index.md
+++ b/content/projects/hugegraph/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HugeGraph? Send your report to the [Apache HugeGraph Security Team](mailto:security%40hugegraph.apache.org?subject=%5BFINDING%5D%20Apache%20HugeGraph).
+Do you want disclose a potential security issue for Apache HugeGraph? Send your report to the [Apache HugeGraph Security Team](mailto:security@hugegraph.apache.org?subject=HugeGraph).
 
 You can read more about the security policy on:
 

--- a/content/projects/ignite/_index.md
+++ b/content/projects/ignite/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ignite? Send your report to the [Apache Ignite Security Team](mailto:security%40ignite.apache.org?subject=%5BFINDING%5D%20Apache%20Ignite).
+Do you want disclose a potential security issue for Apache Ignite? Send your report to the [Apache Ignite Security Team](mailto:security@ignite.apache.org?subject=Ignite).
 
 You can read more about the security policy on:
 

--- a/content/projects/ignite/_index.md
+++ b/content/projects/ignite/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ignite? You can read more about the projects' security policy on their [security page](https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model), and email your report to the [Apache Ignite Security Team](mailto:security@ignite.apache.org).
+Do you want disclose a potential security issue for Apache Ignite? Send your report to the [Apache Ignite Security Team](mailto:security%40ignite.apache.org?subject=%5BFINDING%5D%20Apache%20Ignite).
+
+You can read more about the security policy on:
+
+- [Apache Ignite security model](https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://ignite.apache.org/docs/ignite3/3.1.0/understand/architecture/security#security-model). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## REST HTTP arbitrary file read vulnerability ## { #CVE-2025-48977 }

--- a/content/projects/impala/_index.md
+++ b/content/projects/impala/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Impala? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Impala).
+Do you want disclose a potential security issue for Apache Impala? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Impala).
 
 You can read more about the security policy on:
 

--- a/content/projects/impala/_index.md
+++ b/content/projects/impala/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Impala? You can read more about the projects' security policy on their [security page](https://github.com/apache/impala/security/policy), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Impala? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Impala).
+
+You can read more about the security policy on:
+
+- [Apache Impala security model](https://github.com/apache/impala/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/impala/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Impala logs contain secrets ## { #CVE-2021-28131 }

--- a/content/projects/inlong/_index.md
+++ b/content/projects/inlong/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache InLong? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20InLong).
+Do you want disclose a potential security issue for Apache InLong? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=InLong).
 
 You can read more about the security policy on:
 

--- a/content/projects/inlong/_index.md
+++ b/content/projects/inlong/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache InLong? You can read more about the projects' security policy on their [security page](https://inlong.apache.org/docs/next/security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache InLong? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20InLong).
+
+You can read more about the security policy on:
+
+- [Apache InLong security model](https://inlong.apache.org/docs/next/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://inlong.apache.org/docs/next/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## An arbitrary file read vulnerability for JDBC ## { #CVE-2025-27531 }

--- a/content/projects/iotdb/_index.md
+++ b/content/projects/iotdb/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache IoTDB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20IoTDB).
+Do you want disclose a potential security issue for Apache IoTDB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=IoTDB).
 
 You can read more about the security policy on:
 

--- a/content/projects/iotdb/_index.md
+++ b/content/projects/iotdb/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache IoTDB? You can read more about the projects' security policy on their [security page](https://github.com/apache/iotdb/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache IoTDB? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20IoTDB).
+
+You can read more about the security policy on:
+
+- [Apache IoTDB security model](https://github.com/apache/iotdb/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/iotdb/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Out-of-bounds reads in C++ client TsBlock deserializer crash client process on malformed server data ## { #CVE-2026-40454 }

--- a/content/projects/isis/_index.md
+++ b/content/projects/isis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Isis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Isis).
+Do you want disclose a potential security issue for Apache Isis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Isis).
 
 # Advisories
 

--- a/content/projects/isis/_index.md
+++ b/content/projects/isis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Isis? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Isis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Isis).
 
 # Advisories
 

--- a/content/projects/jackrabbit/_index.md
+++ b/content/projects/jackrabbit/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Jackrabbit? Send your report to the [Apache Jackrabbit Security Team](mailto:security%40jackrabbit.apache.org?subject=%5BFINDING%5D%20Apache%20Jackrabbit).
+Do you want disclose a potential security issue for Apache Jackrabbit? Send your report to the [Apache Jackrabbit Security Team](mailto:security@jackrabbit.apache.org?subject=Jackrabbit).
 
 You can read more about the security policy on:
 

--- a/content/projects/jackrabbit/_index.md
+++ b/content/projects/jackrabbit/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Jackrabbit? You can read more about the projects' security policy on their [security page](https://jackrabbit.apache.org/jcr/security-reports.html), and email your report to the [Apache Jackrabbit Security Team](mailto:security@jackrabbit.apache.org).
+Do you want disclose a potential security issue for Apache Jackrabbit? Send your report to the [Apache Jackrabbit Security Team](mailto:security%40jackrabbit.apache.org?subject=%5BFINDING%5D%20Apache%20Jackrabbit).
+
+You can read more about the security policy on:
+
+- [Apache Jackrabbit security model](https://jackrabbit.apache.org/jcr/security-reports.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://jackrabbit.apache.org/jcr/security-reports.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## JNDI injection risk with JndiRepositoryFactory ## { #CVE-2025-58782 }

--- a/content/projects/james/_index.md
+++ b/content/projects/james/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache James? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20James).
+Do you want disclose a potential security issue for Apache James? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=James).
 
 # Advisories
 

--- a/content/projects/james/_index.md
+++ b/content/projects/james/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache James? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache James? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20James).
 
 # Advisories
 

--- a/content/projects/jena/_index.md
+++ b/content/projects/jena/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Jena? You can read more about the projects' security policy on their [security page](https://github.com/apache/jena/blob/main/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Jena? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Jena).
+
+You can read more about the security policy on:
+
+- [Apache Jena security model](https://github.com/apache/jena/blob/main/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/jena/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Configuration files uploaded by administrative users are not check properly ## { #CVE-2025-50151 }

--- a/content/projects/jena/_index.md
+++ b/content/projects/jena/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Jena? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Jena).
+Do you want disclose a potential security issue for Apache Jena? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Jena).
 
 You can read more about the security policy on:
 

--- a/content/projects/johnzon/_index.md
+++ b/content/projects/johnzon/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Johnzon? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Johnzon).
+Do you want disclose a potential security issue for Apache Johnzon? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Johnzon).
 
 You can read more about the security policy on:
 

--- a/content/projects/johnzon/_index.md
+++ b/content/projects/johnzon/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Johnzon? You can read more about the projects' security policy on their [security page](https://johnzon.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Johnzon? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Johnzon).
+
+You can read more about the security policy on:
+
+- [Apache Johnzon security model](https://johnzon.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://johnzon.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Prevent inefficient internal conversion from BigDecimal at large scale ## { #CVE-2023-33008 }

--- a/content/projects/jspwiki/_index.md
+++ b/content/projects/jspwiki/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache JSPWiki? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20JSPWiki).
+Do you want disclose a potential security issue for Apache JSPWiki? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=JSPWiki).
 
 You can read more about the security policy on:
 

--- a/content/projects/jspwiki/_index.md
+++ b/content/projects/jspwiki/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache JSPWiki? You can read more about the projects' security policy on their [security page](https://github.com/apache/jspwiki/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache JSPWiki? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20JSPWiki).
+
+You can read more about the security policy on:
+
+- [Apache JSPWiki security model](https://github.com/apache/jspwiki/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/jspwiki/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Cross-Site Scripting (XSS) in JSPWiki Image plugin ## { #CVE-2025-24854 }

--- a/content/projects/juddi/_index.md
+++ b/content/projects/juddi/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache jUDDI? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20jUDDI).
+Do you want disclose a potential security issue for Apache jUDDI? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=jUDDI).
 
 # Advisories
 

--- a/content/projects/juddi/_index.md
+++ b/content/projects/juddi/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache jUDDI? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache jUDDI? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20jUDDI).
 
 # Advisories
 

--- a/content/projects/kafka/_index.md
+++ b/content/projects/kafka/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kafka? You can read more about the projects' security policy on their [security page](https://kafka.apache.org/project-security.html), and email your report to the [Apache Kafka Security Team](mailto:security@kafka.apache.org).
+Do you want disclose a potential security issue for Apache Kafka? Send your report to the [Apache Kafka Security Team](mailto:security%40kafka.apache.org?subject=%5BFINDING%5D%20Apache%20Kafka).
+
+You can read more about the security policy on:
+
+- [Apache Kafka security model](https://kafka.apache.org/project-security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://kafka.apache.org/project-security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Improper Authorization in CONSUMER_GROUP_DESCRIBE API ## { #CVE-2026-41115 }

--- a/content/projects/kafka/_index.md
+++ b/content/projects/kafka/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kafka? Send your report to the [Apache Kafka Security Team](mailto:security%40kafka.apache.org?subject=%5BFINDING%5D%20Apache%20Kafka).
+Do you want disclose a potential security issue for Apache Kafka? Send your report to the [Apache Kafka Security Team](mailto:security@kafka.apache.org?subject=Kafka).
 
 You can read more about the security policy on:
 

--- a/content/projects/karaf/_index.md
+++ b/content/projects/karaf/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Karaf? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Karaf? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Karaf).
 
 # Advisories
 

--- a/content/projects/karaf/_index.md
+++ b/content/projects/karaf/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Karaf? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Karaf).
+Do you want disclose a potential security issue for Apache Karaf? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Karaf).
 
 # Advisories
 

--- a/content/projects/knox/_index.md
+++ b/content/projects/knox/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Knox? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Knox).
+Do you want disclose a potential security issue for Apache Knox? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Knox).
 
 # Advisories
 

--- a/content/projects/knox/_index.md
+++ b/content/projects/knox/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Knox? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Knox? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Knox).
 
 # Advisories
 

--- a/content/projects/kvrocks/_index.md
+++ b/content/projects/kvrocks/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kvrocks? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kvrocks).
+Do you want disclose a potential security issue for Apache Kvrocks? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Kvrocks).
 
 You can read more about the security policy on:
 

--- a/content/projects/kvrocks/_index.md
+++ b/content/projects/kvrocks/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kvrocks? You can read more about the projects' security policy on their [security page](https://github.com/apache/kvrocks/blob/unstable/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Kvrocks? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kvrocks).
+
+You can read more about the security policy on:
+
+- [Apache Kvrocks security model](https://github.com/apache/kvrocks/blob/unstable/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/kvrocks/blob/unstable/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## RESTORE IntSet Integer Overflow Leads to Remote DoS ## { #CVE-2026-54226 }

--- a/content/projects/kylin/_index.md
+++ b/content/projects/kylin/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kylin? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Kylin? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kylin).
 
 # Advisories
 

--- a/content/projects/kylin/_index.md
+++ b/content/projects/kylin/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kylin? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Kylin).
+Do you want disclose a potential security issue for Apache Kylin? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Kylin).
 
 # Advisories
 

--- a/content/projects/kyuubi/_index.md
+++ b/content/projects/kyuubi/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kyuubi? Send your report to the [Apache Kyuubi Security Team](mailto:security@kyuubi.apache.org).
+Do you want disclose a potential security issue for Apache Kyuubi? Send your report to the [Apache Kyuubi Security Team](mailto:security%40kyuubi.apache.org?subject=%5BFINDING%5D%20Apache%20Kyuubi).
 
 # Advisories
 

--- a/content/projects/kyuubi/_index.md
+++ b/content/projects/kyuubi/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Kyuubi? Send your report to the [Apache Kyuubi Security Team](mailto:security%40kyuubi.apache.org?subject=%5BFINDING%5D%20Apache%20Kyuubi).
+Do you want disclose a potential security issue for Apache Kyuubi? Send your report to the [Apache Kyuubi Security Team](mailto:security@kyuubi.apache.org?subject=Kyuubi).
 
 # Advisories
 

--- a/content/projects/linkis/_index.md
+++ b/content/projects/linkis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Linkis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Linkis).
+Do you want disclose a potential security issue for Apache Linkis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Linkis).
 
 # Advisories
 

--- a/content/projects/linkis/_index.md
+++ b/content/projects/linkis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Linkis? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Linkis? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Linkis).
 
 # Advisories
 

--- a/content/projects/livy/_index.md
+++ b/content/projects/livy/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Livy? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Livy? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Livy).
 
 # Advisories
 

--- a/content/projects/livy/_index.md
+++ b/content/projects/livy/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Livy? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Livy).
+Do you want disclose a potential security issue for Apache Livy? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Livy).
 
 # Advisories
 

--- a/content/projects/logging/_index.md
+++ b/content/projects/logging/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Logging? You can read more about the projects' security policy on their [security page](https://logging.apache.org/security.html), and email your report to the [Apache Logging Security Team](mailto:security@logging.apache.org).
+Do you want disclose a potential security issue for Apache Logging? Send your report to the [Apache Logging Security Team](mailto:security%40logging.apache.org?subject=%5BFINDING%5D%20Apache%20Logging).
+
+You can read more about the security policy on:
+
+- [Apache Logging security model](https://logging.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://logging.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Improper serialization of non-finite floating-point values in MapMessage.asJson() ## { #CVE-2026-49844 }

--- a/content/projects/logging/_index.md
+++ b/content/projects/logging/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Logging? Send your report to the [Apache Logging Security Team](mailto:security%40logging.apache.org?subject=%5BFINDING%5D%20Apache%20Logging).
+Do you want disclose a potential security issue for Apache Logging? Send your report to the [Apache Logging Security Team](mailto:security@logging.apache.org?subject=Logging).
 
 You can read more about the security policy on:
 

--- a/content/projects/lucene/_index.md
+++ b/content/projects/lucene/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Lucene? Send your report to the [Apache Lucene Security Team](mailto:security@lucene.apache.org).
+Do you want disclose a potential security issue for Apache Lucene? Send your report to the [Apache Lucene Security Team](mailto:security%40lucene.apache.org?subject=%5BFINDING%5D%20Apache%20Lucene).
 
 # Advisories
 

--- a/content/projects/lucene/_index.md
+++ b/content/projects/lucene/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Lucene? Send your report to the [Apache Lucene Security Team](mailto:security%40lucene.apache.org?subject=%5BFINDING%5D%20Apache%20Lucene).
+Do you want disclose a potential security issue for Apache Lucene? Send your report to the [Apache Lucene Security Team](mailto:security@lucene.apache.org?subject=Lucene).
 
 # Advisories
 

--- a/content/projects/lucenenet/_index.md
+++ b/content/projects/lucenenet/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Lucene.NET? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Lucene.NET).
+Do you want disclose a potential security issue for Apache Lucene.NET? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Lucene.NET).
 
 # Advisories
 

--- a/content/projects/lucenenet/_index.md
+++ b/content/projects/lucenenet/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Lucene.NET? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Lucene.NET? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Lucene.NET).
 
 # Advisories
 

--- a/content/projects/manifoldcf/_index.md
+++ b/content/projects/manifoldcf/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ManifoldCF? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ManifoldCF? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ManifoldCF).
 
 # Advisories
 

--- a/content/projects/manifoldcf/_index.md
+++ b/content/projects/manifoldcf/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ManifoldCF? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ManifoldCF).
+Do you want disclose a potential security issue for Apache ManifoldCF? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=ManifoldCF).
 
 # Advisories
 

--- a/content/projects/maven/_index.md
+++ b/content/projects/maven/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Maven? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Maven).
+Do you want disclose a potential security issue for Apache Maven? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Maven).
 
 You can read more about the security policy on:
 

--- a/content/projects/maven/_index.md
+++ b/content/projects/maven/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Maven? You can read more about the projects' security policy on their [security page](https://github.com/apache/maven/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Maven? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Maven).
+
+You can read more about the security policy on:
+
+- [Apache Maven security model](https://github.com/apache/maven/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/maven/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Maven Archetype integration-test may package local settings into the published artifact, possibly containing credentials ## { #CVE-2024-47197 }

--- a/content/projects/mina/_index.md
+++ b/content/projects/mina/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache MINA? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MINA).
+Do you want disclose a potential security issue for Apache MINA? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=MINA).
 
 # Advisories
 

--- a/content/projects/mina/_index.md
+++ b/content/projects/mina/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache MINA? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache MINA? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MINA).
 
 # Advisories
 

--- a/content/projects/mxnet/_index.md
+++ b/content/projects/mxnet/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache MXNet? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MXNet).
+Do you want disclose a potential security issue for Apache MXNet? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=MXNet).
 
 # Advisories
 

--- a/content/projects/mxnet/_index.md
+++ b/content/projects/mxnet/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache MXNet? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache MXNet? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MXNet).
 
 # Advisories
 

--- a/content/projects/myfaces/_index.md
+++ b/content/projects/myfaces/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache MyFaces? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MyFaces).
+Do you want disclose a potential security issue for Apache MyFaces? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=MyFaces).
 
 # Advisories
 

--- a/content/projects/myfaces/_index.md
+++ b/content/projects/myfaces/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache MyFaces? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache MyFaces? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20MyFaces).
 
 # Advisories
 

--- a/content/projects/mynewt/_index.md
+++ b/content/projects/mynewt/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Mynewt? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Mynewt? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Mynewt).
 
 # Advisories
 

--- a/content/projects/mynewt/_index.md
+++ b/content/projects/mynewt/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Mynewt? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Mynewt).
+Do you want disclose a potential security issue for Apache Mynewt? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Mynewt).
 
 # Advisories
 

--- a/content/projects/nifi/_index.md
+++ b/content/projects/nifi/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache NiFi? You can read more about the projects' security policy on their [security page](https://nifi.apache.org/documentation/security/), and email your report to the [Apache NiFi Security Team](mailto:security@nifi.apache.org).
+Do you want disclose a potential security issue for Apache NiFi? Send your report to the [Apache NiFi Security Team](mailto:security%40nifi.apache.org?subject=%5BFINDING%5D%20Apache%20NiFi).
+
+You can read more about the security policy on:
+
+- [Apache NiFi security model](https://nifi.apache.org/documentation/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://nifi.apache.org/documentation/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Missing Validation for Proxy Host Headers ## { #CVE-2026-54665 }

--- a/content/projects/nifi/_index.md
+++ b/content/projects/nifi/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache NiFi? Send your report to the [Apache NiFi Security Team](mailto:security%40nifi.apache.org?subject=%5BFINDING%5D%20Apache%20NiFi).
+Do you want disclose a potential security issue for Apache NiFi? Send your report to the [Apache NiFi Security Team](mailto:security@nifi.apache.org?subject=NiFi).
 
 You can read more about the security policy on:
 

--- a/content/projects/nutch/_index.md
+++ b/content/projects/nutch/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Nutch? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Nutch).
+Do you want disclose a potential security issue for Apache Nutch? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Nutch).
 
 You can read more about the security policy on:
 

--- a/content/projects/nutch/_index.md
+++ b/content/projects/nutch/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Nutch? You can read more about the projects' security policy on their [security page](https://github.com/apache/nutch/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Nutch? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Nutch).
+
+You can read more about the security policy on:
+
+- [Apache Nutch security model](https://github.com/apache/nutch/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/nutch/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## An XML external entity (XXE) injection vulnerability exists in the Nutch DmozParser ## { #CVE-2021-23901 }

--- a/content/projects/nuttx/_index.md
+++ b/content/projects/nuttx/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache NuttX? You can read more about the projects' security policy on their [security page](https://nuttx.apache.org/docs/latest/security.html), and email your report to the [Apache NuttX Security Team](mailto:security@nuttx.apache.org).
+Do you want disclose a potential security issue for Apache NuttX? Send your report to the [Apache NuttX Security Team](mailto:security%40nuttx.apache.org?subject=%5BFINDING%5D%20Apache%20NuttX).
+
+You can read more about the security policy on:
+
+- [Apache NuttX security model](https://nuttx.apache.org/docs/latest/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://nuttx.apache.org/docs/latest/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## fs/vfs/fs_rename: use after free ## { #CVE-2025-48769 }

--- a/content/projects/nuttx/_index.md
+++ b/content/projects/nuttx/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache NuttX? Send your report to the [Apache NuttX Security Team](mailto:security%40nuttx.apache.org?subject=%5BFINDING%5D%20Apache%20NuttX).
+Do you want disclose a potential security issue for Apache NuttX? Send your report to the [Apache NuttX Security Team](mailto:security@nuttx.apache.org?subject=NuttX).
 
 You can read more about the security policy on:
 

--- a/content/projects/ofbiz/_index.md
+++ b/content/projects/ofbiz/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OFBiz? You can read more about the projects' security policy on their [security page](https://ofbiz.apache.org/security.html), and email your report to the [Apache OFBiz Security Team](mailto:security@ofbiz.apache.org).
+Do you want disclose a potential security issue for Apache OFBiz? Send your report to the [Apache OFBiz Security Team](mailto:security%40ofbiz.apache.org?subject=%5BFINDING%5D%20Apache%20OFBiz).
+
+You can read more about the security policy on:
+
+- [Apache OFBiz security model](https://ofbiz.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://ofbiz.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## DataResource Low-Privileged Authenticated FreeMarker Template Injection Leads to Remote Code Execution ## { #CVE-2026-50223 }

--- a/content/projects/ofbiz/_index.md
+++ b/content/projects/ofbiz/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OFBiz? Send your report to the [Apache OFBiz Security Team](mailto:security%40ofbiz.apache.org?subject=%5BFINDING%5D%20Apache%20OFBiz).
+Do you want disclose a potential security issue for Apache OFBiz? Send your report to the [Apache OFBiz Security Team](mailto:security@ofbiz.apache.org?subject=OFBiz).
 
 You can read more about the security policy on:
 

--- a/content/projects/oozie/_index.md
+++ b/content/projects/oozie/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Oozie? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Oozie? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Oozie).
 
 # Advisories
 

--- a/content/projects/oozie/_index.md
+++ b/content/projects/oozie/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Oozie? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Oozie).
+Do you want disclose a potential security issue for Apache Oozie? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Oozie).
 
 # Advisories
 

--- a/content/projects/openmeetings/_index.md
+++ b/content/projects/openmeetings/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OpenMeetings? You can read more about the projects' security policy on their [security page](https://openmeetings.apache.org/security.html), and email your report to the [Apache OpenMeetings Security Team](mailto:security@openmeetings.apache.org).
+Do you want disclose a potential security issue for Apache OpenMeetings? Send your report to the [Apache OpenMeetings Security Team](mailto:security%40openmeetings.apache.org?subject=%5BFINDING%5D%20Apache%20OpenMeetings).
+
+You can read more about the security policy on:
+
+- [Apache OpenMeetings security model](https://openmeetings.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://openmeetings.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Arbitrary File Read ## { #CVE-2026-49488 }

--- a/content/projects/openmeetings/_index.md
+++ b/content/projects/openmeetings/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OpenMeetings? Send your report to the [Apache OpenMeetings Security Team](mailto:security%40openmeetings.apache.org?subject=%5BFINDING%5D%20Apache%20OpenMeetings).
+Do you want disclose a potential security issue for Apache OpenMeetings? Send your report to the [Apache OpenMeetings Security Team](mailto:security@openmeetings.apache.org?subject=OpenMeetings).
 
 You can read more about the security policy on:
 

--- a/content/projects/opennlp/_index.md
+++ b/content/projects/opennlp/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OpenNLP? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenNLP).
+Do you want disclose a potential security issue for Apache OpenNLP? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=OpenNLP).
 
 # Advisories
 

--- a/content/projects/opennlp/_index.md
+++ b/content/projects/opennlp/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OpenNLP? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache OpenNLP? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20OpenNLP).
 
 # Advisories
 

--- a/content/projects/openoffice/_index.md
+++ b/content/projects/openoffice/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OpenOffice? Send your report to the [Apache OpenOffice Security Team](mailto:security%40openoffice.apache.org?subject=%5BFINDING%5D%20Apache%20OpenOffice).
+Do you want disclose a potential security issue for Apache OpenOffice? Send your report to the [Apache OpenOffice Security Team](mailto:security@openoffice.apache.org?subject=OpenOffice).
 
 You can read more about the security policy on:
 

--- a/content/projects/openoffice/_index.md
+++ b/content/projects/openoffice/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache OpenOffice? You can read more about the projects' security policy on their [security page](https://openoffice.apache.org/security), and email your report to the [Apache OpenOffice Security Team](mailto:security@openoffice.apache.org).
+Do you want disclose a potential security issue for Apache OpenOffice? Send your report to the [Apache OpenOffice Security Team](mailto:security%40openoffice.apache.org?subject=%5BFINDING%5D%20Apache%20OpenOffice).
+
+You can read more about the security policy on:
+
+- [Apache OpenOffice security model](https://openoffice.apache.org/security)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://openoffice.apache.org/security). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## URL fetching can be used to exfiltrate arbitrary INI file values and environment variables ## { #CVE-2025-64407 }

--- a/content/projects/orc/_index.md
+++ b/content/projects/orc/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ORC? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ORC).
+Do you want disclose a potential security issue for Apache ORC? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=ORC).
 
 You can read more about the security policy on:
 

--- a/content/projects/orc/_index.md
+++ b/content/projects/orc/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ORC? You can read more about the projects' security policy on their [security page](https://orc.apache.org/security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ORC? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ORC).
+
+You can read more about the security policy on:
+
+- [Apache ORC security model](https://orc.apache.org/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://orc.apache.org/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Potential Heap Buffer Overflow during C++ LZO Decompression ## { #CVE-2025-47436 }

--- a/content/projects/ozone/_index.md
+++ b/content/projects/ozone/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ozone? Send your report to the [Apache Ozone Security Team](mailto:security%40ozone.apache.org?subject=%5BFINDING%5D%20Apache%20Ozone).
+Do you want disclose a potential security issue for Apache Ozone? Send your report to the [Apache Ozone Security Team](mailto:security@ozone.apache.org?subject=Ozone).
 
 You can read more about the security policy on:
 

--- a/content/projects/ozone/_index.md
+++ b/content/projects/ozone/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ozone? You can read more about the projects' security policy on their [security page](https://github.com/apache/ozone/blob/master/THREAT_MODEL.md), and email your report to the [Apache Ozone Security Team](mailto:security@ozone.apache.org).
+Do you want disclose a potential security issue for Apache Ozone? Send your report to the [Apache Ozone Security Team](mailto:security%40ozone.apache.org?subject=%5BFINDING%5D%20Apache%20Ozone).
+
+You can read more about the security policy on:
+
+- [Apache Ozone security model](https://github.com/apache/ozone/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/ozone/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Improper authentication when generating S3 secrets ## { #CVE-2024-45106 }

--- a/content/projects/parquet/_index.md
+++ b/content/projects/parquet/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Parquet? You can read more about the projects' security policy on their [security page](https://github.com/apache/parquet-java/blob/master/SECURITY.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Parquet? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Parquet).
+
+You can read more about the security policy on:
+
+- [Apache Parquet security model](https://github.com/apache/parquet-java/blob/master/SECURITY.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/parquet-java/blob/master/SECURITY.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Potential malicious code execution from trusted packages in the parquet-avro module when reading an Avro schema from a Parquet file metadata ## { #CVE-2025-46762 }

--- a/content/projects/parquet/_index.md
+++ b/content/projects/parquet/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Parquet? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Parquet).
+Do you want disclose a potential security issue for Apache Parquet? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Parquet).
 
 You can read more about the security policy on:
 

--- a/content/projects/pdfbox/_index.md
+++ b/content/projects/pdfbox/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache PDFBox? You can read more about the projects' security policy on their [security page](https://pdfbox.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache PDFBox? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PDFBox).
+
+You can read more about the security policy on:
+
+- [Apache PDFBox security model](https://pdfbox.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://pdfbox.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Path Traversal in PDFBox ExtractEmbeddedFiles Example Code ## { #CVE-2026-33929 }

--- a/content/projects/pdfbox/_index.md
+++ b/content/projects/pdfbox/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache PDFBox? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PDFBox).
+Do you want disclose a potential security issue for Apache PDFBox? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=PDFBox).
 
 You can read more about the security policy on:
 

--- a/content/projects/pekko/_index.md
+++ b/content/projects/pekko/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pekko? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pekko).
+Do you want disclose a potential security issue for Apache Pekko? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Pekko).
 
 You can read more about the security policy on:
 

--- a/content/projects/pekko/_index.md
+++ b/content/projects/pekko/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pekko? You can read more about the projects' security policy on their [security page](https://pekko.apache.org/docs/pekko/current/security/index.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Pekko? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pekko).
+
+You can read more about the security policy on:
+
+- [Apache Pekko security model](https://pekko.apache.org/docs/pekko/current/security/index.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://pekko.apache.org/docs/pekko/current/security/index.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## management API basic authentication is not effective ## { #CVE-2025-46548 }

--- a/content/projects/pinot/_index.md
+++ b/content/projects/pinot/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pinot? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pinot).
+Do you want disclose a potential security issue for Apache Pinot? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Pinot).
 
 # Advisories
 

--- a/content/projects/pinot/_index.md
+++ b/content/projects/pinot/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pinot? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Pinot? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pinot).
 
 # Advisories
 

--- a/content/projects/plc4x/_index.md
+++ b/content/projects/plc4x/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache PLC4X? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PLC4X).
+Do you want disclose a potential security issue for Apache PLC4X? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=PLC4X).
 
 You can read more about the security policy on:
 

--- a/content/projects/plc4x/_index.md
+++ b/content/projects/plc4x/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache PLC4X? You can read more about the projects' security policy on their [security page](https://github.com/apache/plc4x/blob/develop/THREAT-MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache PLC4X? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20PLC4X).
+
+You can read more about the security policy on:
+
+- [Apache PLC4X security model](https://github.com/apache/plc4x/blob/develop/THREAT-MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/plc4x/blob/develop/THREAT-MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Apache PLC4X 0.9.0 Buffer overflow in PLC4C via crafted server response ## { #CVE-2021-43083 }

--- a/content/projects/poi/_index.md
+++ b/content/projects/poi/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache POI? You can read more about the projects' security policy on their [security page](https://poi.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache POI? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20POI).
+
+You can read more about the security policy on:
+
+- [Apache POI security model](https://poi.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://poi.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## parsing OOXML based files (xlsx, docx, etc.), poi-ooxml could read unexpected data if underlying zip has duplicate zip entry names ## { #CVE-2025-31672 }

--- a/content/projects/poi/_index.md
+++ b/content/projects/poi/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache POI? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20POI).
+Do you want disclose a potential security issue for Apache POI? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=POI).
 
 You can read more about the security policy on:
 

--- a/content/projects/polaris/_index.md
+++ b/content/projects/polaris/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Polaris? You can read more about the projects' security policy on their [security page](https://github.com/apache/polaris/blob/main/SECURITY-THREAT-MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Polaris? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Polaris).
+
+You can read more about the security policy on:
+
+- [Apache Polaris security model](https://github.com/apache/polaris/blob/main/SECURITY-THREAT-MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/polaris/blob/main/SECURITY-THREAT-MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## write.metadata.path changes could bypass location validation and broaden delegated storage access ## { #CVE-2026-42812 }

--- a/content/projects/polaris/_index.md
+++ b/content/projects/polaris/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Polaris? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Polaris).
+Do you want disclose a potential security issue for Apache Polaris? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Polaris).
 
 You can read more about the security policy on:
 

--- a/content/projects/ponymail/_index.md
+++ b/content/projects/ponymail/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pony Mail? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Pony Mail? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pony%20Mail).
 
 # Advisories
 

--- a/content/projects/ponymail/_index.md
+++ b/content/projects/ponymail/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pony Mail? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pony%20Mail).
+Do you want disclose a potential security issue for Apache Pony Mail? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Pony%20Mail).
 
 # Advisories
 

--- a/content/projects/portals/_index.md
+++ b/content/projects/portals/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Portals? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Portals).
+Do you want disclose a potential security issue for Apache Portals? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Portals).
 
 # Advisories
 

--- a/content/projects/portals/_index.md
+++ b/content/projects/portals/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Portals? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Portals? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Portals).
 
 # Advisories
 

--- a/content/projects/pulsar/_index.md
+++ b/content/projects/pulsar/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pulsar? You can read more about the projects' security policy on their [security page](https://github.com/apache/pulsar/security/policy), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Pulsar? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pulsar).
+
+You can read more about the security policy on:
+
+- [Apache Pulsar security model](https://github.com/apache/pulsar/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/pulsar/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Sensitive information logged in Pulsar's Apache Kafka Connectors ## { #CVE-2025-30677 }

--- a/content/projects/pulsar/_index.md
+++ b/content/projects/pulsar/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Pulsar? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Pulsar).
+Do you want disclose a potential security issue for Apache Pulsar? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Pulsar).
 
 You can read more about the security policy on:
 

--- a/content/projects/ranger/_index.md
+++ b/content/projects/ranger/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ranger? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ranger).
+Do you want disclose a potential security issue for Apache Ranger? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Ranger).
 
 You can read more about the security policy on:
 

--- a/content/projects/ranger/_index.md
+++ b/content/projects/ranger/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Ranger? You can read more about the projects' security policy on their [security page](https://github.com/apache/ranger/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Ranger? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Ranger).
+
+You can read more about the security policy on:
+
+- [Apache Ranger security model](https://github.com/apache/ranger/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/ranger/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Hostname verification bypass in NiFiRegistryClient and NifiClient ## { #CVE-2025-59060 }

--- a/content/projects/rocketmq/_index.md
+++ b/content/projects/rocketmq/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache RocketMQ? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20RocketMQ).
+Do you want disclose a potential security issue for Apache RocketMQ? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=RocketMQ).
 
 You can read more about the security policy on:
 

--- a/content/projects/rocketmq/_index.md
+++ b/content/projects/rocketmq/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache RocketMQ? You can read more about the projects' security policy on their [security page](https://rocketmq.apache.org/docs/security/01security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache RocketMQ? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20RocketMQ).
+
+You can read more about the security policy on:
+
+- [Apache RocketMQ security model](https://rocketmq.apache.org/docs/security/01security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://rocketmq.apache.org/docs/security/01security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Unauthorized Exposure of Sensitive Data ## { #CVE-2024-23321 }

--- a/content/projects/roller/_index.md
+++ b/content/projects/roller/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Roller? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Roller? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Roller).
 
 # Advisories
 

--- a/content/projects/roller/_index.md
+++ b/content/projects/roller/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Roller? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Roller).
+Do you want disclose a potential security issue for Apache Roller? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Roller).
 
 # Advisories
 

--- a/content/projects/santuario/_index.md
+++ b/content/projects/santuario/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Santuario? You can read more about the projects' security policy on their [security page](https://github.com/apache/santuario-xml-security-java/blob/main/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Santuario? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Santuario).
+
+You can read more about the security policy on:
+
+- [Apache Santuario security model](https://github.com/apache/santuario-xml-security-java/blob/main/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/santuario-xml-security-java/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Private Key disclosure in debug-log output ## { #CVE-2023-44483 }

--- a/content/projects/santuario/_index.md
+++ b/content/projects/santuario/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Santuario? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Santuario).
+Do you want disclose a potential security issue for Apache Santuario? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Santuario).
 
 You can read more about the security policy on:
 

--- a/content/projects/seata/_index.md
+++ b/content/projects/seata/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Seata? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Seata).
+Do you want disclose a potential security issue for Apache Seata? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Seata).
 
 You can read more about the security policy on:
 

--- a/content/projects/seata/_index.md
+++ b/content/projects/seata/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Seata? You can read more about the projects' security policy on their [security page](https://seata.apache.org/docs/next/security/secret-key), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Seata? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Seata).
+
+You can read more about the security policy on:
+
+- [Apache Seata security model](https://seata.apache.org/docs/next/security/secret-key)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://seata.apache.org/docs/next/security/secret-key). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Deserialization of untrusted Data in Apache Seata Server ## { #CVE-2025-53606 }

--- a/content/projects/seatunnel/_index.md
+++ b/content/projects/seatunnel/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SeaTunnel? You can read more about the projects' security policy on their [security page](https://seatunnel.apache.org/security), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache SeaTunnel? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SeaTunnel).
+
+You can read more about the security policy on:
+
+- [Apache SeaTunnel security model](https://seatunnel.apache.org/security)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://seatunnel.apache.org/security). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Unauthenticated insecure access ## { #CVE-2025-32896 }

--- a/content/projects/seatunnel/_index.md
+++ b/content/projects/seatunnel/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SeaTunnel? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SeaTunnel).
+Do you want disclose a potential security issue for Apache SeaTunnel? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=SeaTunnel).
 
 You can read more about the security policy on:
 

--- a/content/projects/servicecomb/_index.md
+++ b/content/projects/servicecomb/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ServiceComb? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ServiceComb? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ServiceComb).
 
 # Advisories
 

--- a/content/projects/servicecomb/_index.md
+++ b/content/projects/servicecomb/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ServiceComb? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ServiceComb).
+Do you want disclose a potential security issue for Apache ServiceComb? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=ServiceComb).
 
 # Advisories
 

--- a/content/projects/shardingsphere/_index.md
+++ b/content/projects/shardingsphere/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ShardingSphere? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShardingSphere).
+Do you want disclose a potential security issue for Apache ShardingSphere? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=ShardingSphere).
 
 You can read more about the security policy on:
 

--- a/content/projects/shardingsphere/_index.md
+++ b/content/projects/shardingsphere/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ShardingSphere? You can read more about the projects' security policy on their [security page](https://shardingsphere.apache.org/community/en/security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ShardingSphere? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShardingSphere).
+
+You can read more about the security policy on:
+
+- [Apache ShardingSphere security model](https://shardingsphere.apache.org/community/en/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://shardingsphere.apache.org/community/en/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Deserialization vulnerability in ShardingSphere Agent ## { #CVE-2023-28754 }

--- a/content/projects/shenyu/_index.md
+++ b/content/projects/shenyu/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ShenYu? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShenYu).
+Do you want disclose a potential security issue for Apache ShenYu? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=ShenYu).
 
 You can read more about the security policy on:
 

--- a/content/projects/shenyu/_index.md
+++ b/content/projects/shenyu/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ShenYu? You can read more about the projects' security policy on their [security page](https://github.com/apache/shenyu/blob/master/SECURITY_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache ShenYu? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20ShenYu).
+
+You can read more about the security policy on:
+
+- [Apache ShenYu security model](https://github.com/apache/shenyu/blob/master/SECURITY_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/shenyu/blob/master/SECURITY_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Server-Side Request Forgery in Apache ShenYu ## { #CVE-2023-25753 }

--- a/content/projects/shiro/_index.md
+++ b/content/projects/shiro/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Shiro? Send your report to the [Apache Shiro Security Team](mailto:security%40shiro.apache.org?subject=%5BFINDING%5D%20Apache%20Shiro).
+Do you want disclose a potential security issue for Apache Shiro? Send your report to the [Apache Shiro Security Team](mailto:security@shiro.apache.org?subject=Shiro).
 
 You can read more about the security policy on:
 

--- a/content/projects/shiro/_index.md
+++ b/content/projects/shiro/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Shiro? You can read more about the projects' security policy on their [security page](https://shiro.apache.org/security-reports.html), and email your report to the [Apache Shiro Security Team](mailto:security@shiro.apache.org).
+Do you want disclose a potential security issue for Apache Shiro? Send your report to the [Apache Shiro Security Team](mailto:security%40shiro.apache.org?subject=%5BFINDING%5D%20Apache%20Shiro).
+
+You can read more about the security policy on:
+
+- [Apache Shiro security model](https://shiro.apache.org/security-reports.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://shiro.apache.org/security-reports.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Remember-me cookie isn't checked for expiry on the server ## { #CVE-2026-56130 }

--- a/content/projects/sis/_index.md
+++ b/content/projects/sis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SIS? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache SIS? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SIS).
 
 # Advisories
 

--- a/content/projects/sis/_index.md
+++ b/content/projects/sis/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SIS? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SIS).
+Do you want disclose a potential security issue for Apache SIS? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=SIS).
 
 # Advisories
 

--- a/content/projects/skywalking/_index.md
+++ b/content/projects/skywalking/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SkyWalking? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SkyWalking).
+Do you want disclose a potential security issue for Apache SkyWalking? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=SkyWalking).
 
 You can read more about the security policy on:
 

--- a/content/projects/skywalking/_index.md
+++ b/content/projects/skywalking/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SkyWalking? You can read more about the projects' security policy on their [security page](https://skywalking.apache.org/docs/main/next/en/security/readme/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache SkyWalking? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SkyWalking).
+
+You can read more about the security policy on:
+
+- [Apache SkyWalking security model](https://skywalking.apache.org/docs/main/next/en/security/readme/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://skywalking.apache.org/docs/main/next/en/security/readme/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Server-Side Request Forgery via SW-URL Header in MCP Server ## { #CVE-2026-34476 }

--- a/content/projects/sling/_index.md
+++ b/content/projects/sling/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Sling? Send your report to the [Apache Sling Security Team](mailto:security%40sling.apache.org?subject=%5BFINDING%5D%20Apache%20Sling).
+Do you want disclose a potential security issue for Apache Sling? Send your report to the [Apache Sling Security Team](mailto:security@sling.apache.org?subject=Sling).
 
 You can read more about the security policy on:
 

--- a/content/projects/sling/_index.md
+++ b/content/projects/sling/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Sling? You can read more about the projects' security policy on their [security page](https://github.com/apache/sling/blob/master/docs/threat-model.md), and email your report to the [Apache Sling Security Team](mailto:security@sling.apache.org).
+Do you want disclose a potential security issue for Apache Sling? Send your report to the [Apache Sling Security Team](mailto:security%40sling.apache.org?subject=%5BFINDING%5D%20Apache%20Sling).
+
+You can read more about the security policy on:
+
+- [Apache Sling security model](https://github.com/apache/sling/blob/master/docs/threat-model.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/sling/blob/master/docs/threat-model.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Malicious code execution via path traversal ## { #CVE-2024-23673 }

--- a/content/projects/solr/_index.md
+++ b/content/projects/solr/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Solr? Send your report to the [Apache Solr Security Team](mailto:security%40solr.apache.org?subject=%5BFINDING%5D%20Apache%20Solr).
+Do you want disclose a potential security issue for Apache Solr? Send your report to the [Apache Solr Security Team](mailto:security@solr.apache.org?subject=Solr).
 
 You can read more about the security policy on:
 

--- a/content/projects/solr/_index.md
+++ b/content/projects/solr/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Solr? You can read more about the projects' security policy on their [security page](https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity), and email your report to the [Apache Solr Security Team](mailto:security@solr.apache.org).
+Do you want disclose a potential security issue for Apache Solr? Send your report to the [Apache Solr Security Team](mailto:security%40solr.apache.org?subject=%5BFINDING%5D%20Apache%20Solr).
+
+You can read more about the security policy on:
+
+- [Apache Solr security model](https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Enabling BasicAuth using bin/solr CLI configures additional insecure users ## { #CVE-2026-44825 }

--- a/content/projects/spamassassin/_index.md
+++ b/content/projects/spamassassin/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SpamAssassin? You can read more about the projects' security policy on their [security page](https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy), and email your report to the [Apache SpamAssassin Security Team](mailto:security@spamassassin.apache.org).
+Do you want disclose a potential security issue for Apache SpamAssassin? Send your report to the [Apache SpamAssassin Security Team](mailto:security%40spamassassin.apache.org?subject=%5BFINDING%5D%20Apache%20SpamAssassin).
+
+You can read more about the security policy on:
+
+- [Apache SpamAssassin security model](https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Apache SpamAssassin has an OS Command Injection vulnerability ## { #CVE-2020-1946 }

--- a/content/projects/spamassassin/_index.md
+++ b/content/projects/spamassassin/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SpamAssassin? Send your report to the [Apache SpamAssassin Security Team](mailto:security%40spamassassin.apache.org?subject=%5BFINDING%5D%20Apache%20SpamAssassin).
+Do you want disclose a potential security issue for Apache SpamAssassin? Send your report to the [Apache SpamAssassin Security Team](mailto:security@spamassassin.apache.org?subject=SpamAssassin).
 
 You can read more about the security policy on:
 

--- a/content/projects/spark/_index.md
+++ b/content/projects/spark/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Spark? You can read more about the projects' security policy on their [security page](https://spark.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Spark? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Spark).
+
+You can read more about the security policy on:
+
+- [Apache Spark security model](https://spark.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://spark.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## RPC encryption defaults to unauthenticated AES-CTR mode, enabling man-in-the-middle ciphertext modification attacks ## { #CVE-2025-55039 }

--- a/content/projects/spark/_index.md
+++ b/content/projects/spark/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Spark? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Spark).
+Do you want disclose a potential security issue for Apache Spark? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Spark).
 
 You can read more about the security policy on:
 

--- a/content/projects/storm/_index.md
+++ b/content/projects/storm/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Storm? You can read more about the projects' security policy on their [security page](https://storm.apache.org/security-model.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Storm? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Storm).
+
+You can read more about the security policy on:
+
+- [Apache Storm security model](https://storm.apache.org/security-model.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://storm.apache.org/security-model.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Anonymous principal assigned on TLS client certificate verification failure ## { #CVE-2026-41081 }

--- a/content/projects/storm/_index.md
+++ b/content/projects/storm/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Storm? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Storm).
+Do you want disclose a potential security issue for Apache Storm? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Storm).
 
 You can read more about the security policy on:
 

--- a/content/projects/streampark/_index.md
+++ b/content/projects/streampark/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache StreamPark? You can read more about the projects' security policy on their [security page](https://streampark.apache.org/community/security/), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache StreamPark? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPark).
+
+You can read more about the security policy on:
+
+- [Apache StreamPark security model](https://streampark.apache.org/community/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://streampark.apache.org/community/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Weak Encryption Algorithm in StreamPark ## { #CVE-2025-54981 }

--- a/content/projects/streampark/_index.md
+++ b/content/projects/streampark/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache StreamPark? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPark).
+Do you want disclose a potential security issue for Apache StreamPark? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=StreamPark).
 
 You can read more about the security policy on:
 

--- a/content/projects/streampipes/_index.md
+++ b/content/projects/streampipes/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache StreamPipes? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPipes).
+Do you want disclose a potential security issue for Apache StreamPipes? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=StreamPipes).
 
 You can read more about the security policy on:
 

--- a/content/projects/streampipes/_index.md
+++ b/content/projects/streampipes/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache StreamPipes? You can read more about the projects' security policy on their [security page](https://github.com/apache/streampipes/blob/dev/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache StreamPipes? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20StreamPipes).
+
+You can read more about the security policy on:
+
+- [Apache StreamPipes security model](https://github.com/apache/streampipes/blob/dev/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/streampipes/blob/dev/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Leverage of User ID for Privilege Escalation ## { #CVE-2025-47411 }

--- a/content/projects/struts/_index.md
+++ b/content/projects/struts/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Struts? Send your report to the [Apache Struts Security Team](mailto:security%40struts.apache.org?subject=%5BFINDING%5D%20Apache%20Struts).
+Do you want disclose a potential security issue for Apache Struts? Send your report to the [Apache Struts Security Team](mailto:security@struts.apache.org?subject=Struts).
 
 You can read more about the security policy on:
 

--- a/content/projects/struts/_index.md
+++ b/content/projects/struts/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Struts? You can read more about the projects' security policy on their [security page](https://github.com/apache/struts/blob/main/THREAT_MODEL.md), and email your report to the [Apache Struts Security Team](mailto:security@struts.apache.org).
+Do you want disclose a potential security issue for Apache Struts? Send your report to the [Apache Struts Security Team](mailto:security%40struts.apache.org?subject=%5BFINDING%5D%20Apache%20Struts).
+
+You can read more about the security policy on:
+
+- [Apache Struts security model](https://github.com/apache/struts/blob/main/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/struts/blob/main/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## XXE vulnerability in outdated XWork component ## { #CVE-2025-68493 }

--- a/content/projects/submarine/_index.md
+++ b/content/projects/submarine/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Submarine? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Submarine? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Submarine).
 
 # Advisories
 

--- a/content/projects/submarine/_index.md
+++ b/content/projects/submarine/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Submarine? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Submarine).
+Do you want disclose a potential security issue for Apache Submarine? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Submarine).
 
 # Advisories
 

--- a/content/projects/subversion/_index.md
+++ b/content/projects/subversion/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Subversion? Send your report to the [Apache Subversion Security Team](mailto:security%40subversion.apache.org?subject=%5BFINDING%5D%20Apache%20Subversion).
+Do you want disclose a potential security issue for Apache Subversion? Send your report to the [Apache Subversion Security Team](mailto:security@subversion.apache.org?subject=Subversion).
 
 You can read more about the security policy on:
 

--- a/content/projects/subversion/_index.md
+++ b/content/projects/subversion/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Subversion? You can read more about the projects' security policy on their [security page](https://subversion.apache.org/security/), and email your report to the [Apache Subversion Security Team](mailto:security@subversion.apache.org).
+Do you want disclose a potential security issue for Apache Subversion? Send your report to the [Apache Subversion Security Team](mailto:security%40subversion.apache.org?subject=%5BFINDING%5D%20Apache%20Subversion).
+
+You can read more about the security policy on:
+
+- [Apache Subversion security model](https://subversion.apache.org/security/)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://subversion.apache.org/security/). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## mod_dav_svn denial-of-service via control characters in paths ## { #CVE-2024-46901 }

--- a/content/projects/superset/_index.md
+++ b/content/projects/superset/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Superset? Send your report to the [Apache Superset Security Team](mailto:security%40superset.apache.org?subject=%5BFINDING%5D%20Apache%20Superset).
+Do you want disclose a potential security issue for Apache Superset? Send your report to the [Apache Superset Security Team](mailto:security@superset.apache.org?subject=Superset).
 
 You can read more about the security policy on:
 

--- a/content/projects/superset/_index.md
+++ b/content/projects/superset/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Superset? You can read more about the projects' security policy on their [security page](https://github.com/apache/superset/security/policy), and email your report to the [Apache Superset Security Team](mailto:security@superset.apache.org).
+Do you want disclose a potential security issue for Apache Superset? Send your report to the [Apache Superset Security Team](mailto:security%40superset.apache.org?subject=%5BFINDING%5D%20Apache%20Superset).
+
+You can read more about the security policy on:
+
+- [Apache Superset security model](https://github.com/apache/superset/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/superset/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## SQLLab Read-Only Bypass on PostgreSQL ## { #CVE-2026-23984 }

--- a/content/projects/syncope/_index.md
+++ b/content/projects/syncope/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Syncope? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Syncope).
+Do you want disclose a potential security issue for Apache Syncope? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Syncope).
 
 # Advisories
 

--- a/content/projects/syncope/_index.md
+++ b/content/projects/syncope/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Syncope? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Syncope? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Syncope).
 
 # Advisories
 

--- a/content/projects/systemds/_index.md
+++ b/content/projects/systemds/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SystemDS? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache SystemDS? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SystemDS).
 
 # Advisories
 

--- a/content/projects/systemds/_index.md
+++ b/content/projects/systemds/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache SystemDS? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20SystemDS).
+Do you want disclose a potential security issue for Apache SystemDS? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=SystemDS).
 
 # Advisories
 

--- a/content/projects/tapestry/_index.md
+++ b/content/projects/tapestry/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tapestry? You can read more about the projects' security policy on their [security page](https://github.com/apache/tapestry-5/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Tapestry? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tapestry).
+
+You can read more about the security policy on:
+
+- [Apache Tapestry security model](https://github.com/apache/tapestry-5/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/tapestry-5/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Apache Tapestry prior to version 4 (EOL) allows RCE though deserialization of untrusted input ## { #CVE-2022-46366 }

--- a/content/projects/tapestry/_index.md
+++ b/content/projects/tapestry/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tapestry? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tapestry).
+Do you want disclose a potential security issue for Apache Tapestry? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Tapestry).
 
 You can read more about the security policy on:
 

--- a/content/projects/thrift/_index.md
+++ b/content/projects/thrift/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Thrift? You can read more about the projects' security policy on their [security page](https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Thrift? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Thrift).
+
+You can read more about the security policy on:
+
+- [Apache Thrift security model](https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Node.js web_server.js multi-vulnerability ## { #CVE-2026-43870 }

--- a/content/projects/thrift/_index.md
+++ b/content/projects/thrift/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Thrift? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Thrift).
+Do you want disclose a potential security issue for Apache Thrift? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Thrift).
 
 You can read more about the security policy on:
 

--- a/content/projects/tika/_index.md
+++ b/content/projects/tika/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tika? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tika).
+Do you want disclose a potential security issue for Apache Tika? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Tika).
 
 You can read more about the security policy on:
 

--- a/content/projects/tika/_index.md
+++ b/content/projects/tika/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tika? You can read more about the projects' security policy on their [security page](https://tika.apache.org/security-model.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Tika? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tika).
+
+You can read more about the security policy on:
+
+- [Apache Tika security model](https://tika.apache.org/security-model.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://tika.apache.org/security-model.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Update to CVE-2025-54988 to expand scope of artifacts affected ## { #CVE-2025-66516 }

--- a/content/projects/tiles/_index.md
+++ b/content/projects/tiles/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tiles? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tiles).
+Do you want disclose a potential security issue for Apache Tiles? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Tiles).
 
 # Advisories
 

--- a/content/projects/tiles/_index.md
+++ b/content/projects/tiles/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tiles? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Tiles? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Tiles).
 
 # Advisories
 

--- a/content/projects/tomcat/_index.md
+++ b/content/projects/tomcat/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tomcat? You can read more about the projects' security policy on their [security page](https://tomcat.apache.org/security.html), and email your report to the [Apache Tomcat Security Team](mailto:security@tomcat.apache.org).
+Do you want disclose a potential security issue for Apache Tomcat? Send your report to the [Apache Tomcat Security Team](mailto:security%40tomcat.apache.org?subject=%5BFINDING%5D%20Apache%20Tomcat).
+
+You can read more about the security policy on:
+
+- [Apache Tomcat security model](https://tomcat.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://tomcat.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## EncryptInterceptor requirements not clearly documented ## { #CVE-2026-59084 }

--- a/content/projects/tomcat/_index.md
+++ b/content/projects/tomcat/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Tomcat? Send your report to the [Apache Tomcat Security Team](mailto:security%40tomcat.apache.org?subject=%5BFINDING%5D%20Apache%20Tomcat).
+Do you want disclose a potential security issue for Apache Tomcat? Send your report to the [Apache Tomcat Security Team](mailto:security@tomcat.apache.org?subject=Tomcat).
 
 You can read more about the security policy on:
 

--- a/content/projects/trafficcontrol/_index.md
+++ b/content/projects/trafficcontrol/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Traffic Control? Send your report to the [Apache Traffic Control Security Team](mailto:security%40trafficcontrol.apache.org?subject=%5BFINDING%5D%20Apache%20Traffic%20Control).
+Do you want disclose a potential security issue for Apache Traffic Control? Send your report to the [Apache Traffic Control Security Team](mailto:security@trafficcontrol.apache.org?subject=Traffic%20Control).
 
 You can read more about the security policy on:
 

--- a/content/projects/trafficcontrol/_index.md
+++ b/content/projects/trafficcontrol/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Traffic Control? You can read more about the projects' security policy on their [security page](https://trafficcontrol.apache.org/security/index.html), and email your report to the [Apache Traffic Control Security Team](mailto:security@trafficcontrol.apache.org).
+Do you want disclose a potential security issue for Apache Traffic Control? Send your report to the [Apache Traffic Control Security Team](mailto:security%40trafficcontrol.apache.org?subject=%5BFINDING%5D%20Apache%20Traffic%20Control).
+
+You can read more about the security policy on:
+
+- [Apache Traffic Control security model](https://trafficcontrol.apache.org/security/index.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://trafficcontrol.apache.org/security/index.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## ReDoS issue in Traffic Router configuration ## { #CVE-2025-61581 }

--- a/content/projects/trafficserver/_index.md
+++ b/content/projects/trafficserver/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Traffic Server? Send your report to the [Apache Traffic Server Security Team](mailto:security%40trafficserver.apache.org?subject=%5BFINDING%5D%20Apache%20Traffic%20Server).
+Do you want disclose a potential security issue for Apache Traffic Server? Send your report to the [Apache Traffic Server Security Team](mailto:security@trafficserver.apache.org?subject=Traffic%20Server).
 
 You can read more about the security policy on:
 

--- a/content/projects/trafficserver/_index.md
+++ b/content/projects/trafficserver/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Traffic Server? You can read more about the projects' security policy on their [security page](https://github.com/apache/trafficserver/security/policy), and email your report to the [Apache Traffic Server Security Team](mailto:security@trafficserver.apache.org).
+Do you want disclose a potential security issue for Apache Traffic Server? Send your report to the [Apache Traffic Server Security Team](mailto:security%40trafficserver.apache.org?subject=%5BFINDING%5D%20Apache%20Traffic%20Server).
+
+You can read more about the security policy on:
+
+- [Apache Traffic Server security model](https://github.com/apache/trafficserver/security/policy)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/trafficserver/security/policy). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Malformed chunked message body allows request smuggling ## { #CVE-2025-65114 }

--- a/content/projects/uima/_index.md
+++ b/content/projects/uima/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache UIMA? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20UIMA).
+Do you want disclose a potential security issue for Apache UIMA? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=UIMA).
 
 # Advisories
 

--- a/content/projects/uima/_index.md
+++ b/content/projects/uima/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache UIMA? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache UIMA? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20UIMA).
 
 # Advisories
 

--- a/content/projects/uniffle/_index.md
+++ b/content/projects/uniffle/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Uniffle? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Uniffle).
+Do you want disclose a potential security issue for Apache Uniffle? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Uniffle).
 
 # Advisories
 

--- a/content/projects/uniffle/_index.md
+++ b/content/projects/uniffle/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Uniffle? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Uniffle? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Uniffle).
 
 # Advisories
 

--- a/content/projects/unomi/_index.md
+++ b/content/projects/unomi/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Unomi? You can read more about the projects' security policy on their [security page](https://github.com/apache/unomi/blob/master/THREAT_MODEL.md), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Unomi? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Unomi).
+
+You can read more about the security policy on:
+
+- [Apache Unomi security model](https://github.com/apache/unomi/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/unomi/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Apache Unomi log injection ## { #CVE-2021-31164 }

--- a/content/projects/unomi/_index.md
+++ b/content/projects/unomi/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Unomi? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Unomi).
+Do you want disclose a potential security issue for Apache Unomi? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Unomi).
 
 You can read more about the security policy on:
 

--- a/content/projects/vcl/_index.md
+++ b/content/projects/vcl/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache VCL? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20VCL).
+Do you want disclose a potential security issue for Apache VCL? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=VCL).
 
 # Advisories
 

--- a/content/projects/vcl/_index.md
+++ b/content/projects/vcl/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache VCL? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache VCL? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20VCL).
 
 # Advisories
 

--- a/content/projects/velocity/_index.md
+++ b/content/projects/velocity/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Velocity? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Velocity).
+Do you want disclose a potential security issue for Apache Velocity? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Velocity).
 
 You can read more about the security policy on:
 

--- a/content/projects/velocity/_index.md
+++ b/content/projects/velocity/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Velocity? You can read more about the projects' security policy on their [security page](https://velocity.apache.org/#security-model), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Velocity? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Velocity).
+
+You can read more about the security policy on:
+
+- [Apache Velocity security model](https://velocity.apache.org/#security-model)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://velocity.apache.org/#security-model). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Velocity Tools XSS Vulnerability ## { #CVE-2020-13959 }

--- a/content/projects/wicket/_index.md
+++ b/content/projects/wicket/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Wicket? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Wicket).
+Do you want disclose a potential security issue for Apache Wicket? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Wicket).
 
 # Advisories
 

--- a/content/projects/wicket/_index.md
+++ b/content/projects/wicket/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Wicket? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Wicket? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Wicket).
 
 # Advisories
 

--- a/content/projects/ws/_index.md
+++ b/content/projects/ws/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Web Services? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Web Services? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Web%20Services).
 
 # Advisories
 

--- a/content/projects/ws/_index.md
+++ b/content/projects/ws/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Web Services? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Web%20Services).
+Do you want disclose a potential security issue for Apache Web Services? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Web%20Services).
 
 # Advisories
 

--- a/content/projects/xalan/_index.md
+++ b/content/projects/xalan/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Xalan? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Xalan? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Xalan).
 
 # Advisories
 

--- a/content/projects/xalan/_index.md
+++ b/content/projects/xalan/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Xalan? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Xalan).
+Do you want disclose a potential security issue for Apache Xalan? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Xalan).
 
 # Advisories
 

--- a/content/projects/xerces/_index.md
+++ b/content/projects/xerces/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Xerces? Send your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache Xerces? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Xerces).
 
 # Advisories
 

--- a/content/projects/xerces/_index.md
+++ b/content/projects/xerces/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Xerces? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20Xerces).
+Do you want disclose a potential security issue for Apache Xerces? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Xerces).
 
 # Advisories
 

--- a/content/projects/xmlgraphics/_index.md
+++ b/content/projects/xmlgraphics/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache XML Graphics? You can read more about the projects' security policy on their [security page](https://xmlgraphics.apache.org/security.html), and email your report to the [Apache Security Team](mailto:security@apache.org).
+Do you want disclose a potential security issue for Apache XML Graphics? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20XML%20Graphics).
+
+You can read more about the security policy on:
+
+- [Apache XML Graphics security model](https://xmlgraphics.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://xmlgraphics.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## XML External Entity (XXE) Processing ## { #CVE-2024-28168 }

--- a/content/projects/xmlgraphics/_index.md
+++ b/content/projects/xmlgraphics/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache XML Graphics? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20XML%20Graphics).
+Do you want disclose a potential security issue for Apache XML Graphics? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=XML%20Graphics).
 
 You can read more about the security policy on:
 

--- a/content/projects/zeppelin/_index.md
+++ b/content/projects/zeppelin/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Zeppelin? You can read more about the projects' security policy on their [security page](https://github.com/apache/zeppelin/blob/master/THREAT_MODEL.md), and email your report to the [Apache Zeppelin Security Team](mailto:security@zeppelin.apache.org).
+Do you want disclose a potential security issue for Apache Zeppelin? Send your report to the [Apache Zeppelin Security Team](mailto:security%40zeppelin.apache.org?subject=%5BFINDING%5D%20Apache%20Zeppelin).
+
+You can read more about the security policy on:
+
+- [Apache Zeppelin security model](https://github.com/apache/zeppelin/blob/master/THREAT_MODEL.md)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://github.com/apache/zeppelin/blob/master/THREAT_MODEL.md). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Arbitrary file read by adding malicious JDBC connection string ## { #CVE-2024-52279 }

--- a/content/projects/zeppelin/_index.md
+++ b/content/projects/zeppelin/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Zeppelin? Send your report to the [Apache Zeppelin Security Team](mailto:security%40zeppelin.apache.org?subject=%5BFINDING%5D%20Apache%20Zeppelin).
+Do you want disclose a potential security issue for Apache Zeppelin? Send your report to the [Apache Zeppelin Security Team](mailto:security@zeppelin.apache.org?subject=Zeppelin).
 
 You can read more about the security policy on:
 

--- a/content/projects/zookeeper/_index.md
+++ b/content/projects/zookeeper/_index.md
@@ -6,11 +6,16 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ZooKeeper? You can read more about the projects' security policy on their [security page](https://zookeeper.apache.org/security.html), and email your report to the [Apache ZooKeeper Security Team](mailto:security@zookeeper.apache.org).
+Do you want disclose a potential security issue for Apache ZooKeeper? Send your report to the [Apache ZooKeeper Security Team](mailto:security%40zookeeper.apache.org?subject=%5BFINDING%5D%20Apache%20ZooKeeper).
+
+You can read more about the security policy on:
+
+- [Apache ZooKeeper security model](https://zookeeper.apache.org/security.html)
+
 
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the [project security page](https://zookeeper.apache.org/security.html). If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Sensitive information disclosure in client configuration handling ## { #CVE-2026-24308 }

--- a/content/projects/zookeeper/_index.md
+++ b/content/projects/zookeeper/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache ZooKeeper? Send your report to the [Apache ZooKeeper Security Team](mailto:security%40zookeeper.apache.org?subject=%5BFINDING%5D%20Apache%20ZooKeeper).
+Do you want disclose a potential security issue for Apache ZooKeeper? Send your report to the [Apache ZooKeeper Security Team](mailto:security@zookeeper.apache.org?subject=ZooKeeper).
 
 You can read more about the security policy on:
 

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -299,11 +299,28 @@
   },
   "commons": {
     "name": "Apache Commons",
-    "security_model_link": "https://commons.apache.org/security.html",
-    "security_model_source": "https://svn.apache.org/repos/asf/commons/cms-site/trunk/content/xdoc/security.xml",
+    "security_model_link": "https://commons.apache.org/threat_model.html",
+    "security_model_source": "https://svn.apache.org/repos/asf/commons/cms-site/trunk/content/markdown/threat_model.md",
     "advisory_link": "https://commons.apache.org/security.html#Known_Security_Vulnerabilities",
     "contact": "security@commons.apache.org",
-    "logo_link": "https://www.apache.org/logos/res/commons/default.png"
+    "logo_link": "https://www.apache.org/logos/res/commons/default.png",
+    "projects": [
+      {
+        "name": "Apache Commons Configuration",
+        "security_model_link": "https://commons.apache.org/proper/commons-configuration/security.html",
+        "security_model_source": "https://raw.githubusercontent.com/apache/commons-configuration/refs/heads/master/src/site/xdoc/security.xml"
+      },
+      {
+        "name": "Apache Commons Imaging",
+        "security_model_link": "https://commons.apache.org/proper/commons-imaging/security.html",
+        "security_model_source": "https://raw.githubusercontent.com/apache/commons-imaging/refs/heads/master/src/site/xdoc/security.xml"
+      },
+      {
+        "name": "Apache Commons XML",
+        "security_model_link": "https://commons.apache.org/sandbox/commons-xml/threat_model.html",
+        "security_model_source": "https://raw.githubusercontent.com/apache/commons-xml/refs/heads/main/src/site/markdown/threat_model.md"
+      }
+    ]
   },
   "cordova": {
     "name": "Apache Cordova",

--- a/scripts/project-coordinates.schema.json
+++ b/scripts/project-coordinates.schema.json
@@ -14,7 +14,7 @@
     }
   },
   "additionalProperties": {
-    "$ref": "#/$defs/project"
+    "$ref": "#/$defs/pmc"
   },
   "$defs": {
     "urlOrNull": {
@@ -23,16 +23,12 @@
     },
     "project": {
       "type": "object",
-      "description": "Security coordinates for a single project. The six core fields are always present (null when unknown) so consumers need no per-field presence checks.",
+      "description": "A named piece of software with its own security model. Used both on its own, for the individual projects a PMC ships (see 'pmc/projects'), and as the base a 'pmc' extends. This definition deliberately does not forbid extra properties: 'additionalProperties: false' only sees the properties declared alongside it, so it would reject the extra keys a 'pmc' adds on top. Each place that uses this definition closes itself with 'unevaluatedProperties: false' instead, which does account for inherited properties.",
       "required": [
         "name",
         "security_model_link",
-        "security_model_source",
-        "advisory_link",
-        "contact",
-        "logo_link"
+        "security_model_source"
       ],
-      "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
@@ -46,7 +42,26 @@
         "security_model_source": {
           "$ref": "#/$defs/urlOrNull",
           "description": "URL of an AI-friendly plain-text/Markdown version of the security page. Not rendered on the site; used by external tooling to fetch text instead of HTML. Null when unavailable."
-        },
+        }
+      }
+    },
+    "pmc": {
+      "description": "Security coordinates for a single PMC (or podling), keyed by committee id. Extends 'project': a PMC has a name and its own security model, plus the reporting and advisory coordinates below. The six core fields are always present (null when unknown) so consumers need no per-field presence checks.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/project"
+        }
+      ],
+      "required": [
+        "name",
+        "security_model_link",
+        "security_model_source",
+        "advisory_link",
+        "contact",
+        "logo_link"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
         "advisory_link": {
           "$ref": "#/$defs/urlOrNull",
           "description": "URL of the project's published list of security advisories. Null when the project has none."
@@ -68,6 +83,19 @@
         "dependency_advisory_triage": {
           "$ref": "#/$defs/urlOrNull",
           "description": "Optional URL of the project's dependency-advisory triage data (e.g. VEX or suppression file)."
+        },
+        "projects": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Optional list of the individual projects this PMC ships, for PMCs that maintain more than one. Only needed when a project publishes a security model of its own, distinct from the PMC-wide one above; the PMC's reporting and advisory coordinates cover them all.",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/$defs/project"
+              }
+            ],
+            "unevaluatedProperties": false
+          }
         }
       }
     }

--- a/scripts/project-page.py
+++ b/scripts/project-page.py
@@ -90,6 +90,23 @@ def project_letter(name):
     c = d[0].upper() if d else '#'
     return c if c.isalpha() else '#'
 
+def security_models(p):
+    # The PMC's own security model first, then one per project it ships that
+    # publishes a model of its own. Most PMCs have only the umbrella entry; a
+    # PMC with several projects carries a "projects" list in the coordinates.
+    models = []
+    if p.get('security_model_link'):
+        models.append((p['name'], p['security_model_link']))
+    for project in p.get('projects') or []:
+        if project.get('security_model_link'):
+            models.append((project['name'], project['security_model_link']))
+    return models
+
+def security_model_md_lines(models, indent):
+    # One Markdown list item per security model, each labelled with the name of the project it covers.
+    # Callers supply the indent the surrounding list needs.
+    return ['%s- [%s security model](%s)' % (indent, name, link) for name, link in models]
+
 def project_md_lines(pmc, p):
     # Each project is a Markdown list item: a bold name plus a nested list of
     # labelled links. Security contact comes first and is always present.
@@ -132,9 +149,10 @@ def project_md_lines(pmc, p):
             lines.append('    [security.apache.org](/projects/%s/)' % pmc)
         else:
             lines.append('    none so far')
-    if p.get('security_model_link'):
-        lines.append('  - Security page:\\')
-        lines.append('    [%s](%s)' % (urlparse(p['security_model_link']).netloc or 'security page', p['security_model_link']))
+    models = security_models(p)
+    if models:
+        lines.append('  - Security model:' if len(models) == 1 else '  - Security models:')
+        lines += security_model_md_lines(models, '    ')
     return lines
 
 # Group projects by their initial letter (non-letters bucket under '#').
@@ -197,23 +215,29 @@ layout: single
 ---
 
 """ % (p['name'], p['name']))
+    models = security_models(p)
     project_page.write('# Reporting\n\n')
     project_page.write('Do you want disclose a potential security issue for %s? ' % p['name'])
-    if 'security_model_link' in p.keys() and p['security_model_link']:
-        project_page.write("You can read more about the projects' security policy on their [security page](%s), and email your report to the " % p['security_model_link'])
-    else:
-        project_page.write('Send your report to the ')
+    project_page.write('Send your report to the ')
+    subject = '[FINDING] %s' % p['name']
     if not 'contact' in p.keys() or p['contact'] == 'security@apache.org':
-        project_page.write('[Apache Security Team](mailto:security@apache.org).')
+        project_page.write('[Apache Security Team](mailto:security@apache.org?subject=%s).' % quote(subject))
     else:
-        project_page.write('[%s Security Team](mailto:%s).' % (p['name'], p['contact']))
+        project_page.write('[%s Security Team](mailto:%s?subject=%s).' % (p['name'], quote(p['contact']), quote(subject)))
+    if models:
+        # A PMC that ships several projects publishes one security model per
+        # project, so these are listed rather than woven into the sentence.
+        project_page.write("\n\nYou can read more about the security policy on:\n\n")
+        project_page.write('\n'.join(security_model_md_lines(models, '')))
+        project_page.write('\n')
 
     project_page.write('\n\n# Advisories')
 
     project_page.write('\n\nThis section is experimental: it provides advisories since 2023 and ')
     project_page.write('may lag behind the official CVE publications. ')
-    if 'security_model_link' in p.keys() and p['security_model_link']:
-        project_page.write('It may also lack details found on the [project security page](%s). ' % p['security_model_link'])
+    if models:
+        project_page.write('It may also lack details found on the project security page%s linked above. ' % (
+            's' if len(models) > 1 else ''))
 
     project_page.write('If you have any feedback on how you would like this data to be provided, ')
     project_page.write('you are welcome to reach out on our public [mailinglist](/mailinglist) or privately ')

--- a/scripts/project-page.py
+++ b/scripts/project-page.py
@@ -49,7 +49,7 @@ layout: single
 
 Here is a list of pages ASF projects maintain to provide information on known security vulnerabilities. Each entry also has the security contact for reporting new vulnerabilities related to that project. Note that not all project security teams have a dedicated address for reporting new vulnerabilities.
 
-To report a vulnerability in an Apache project that is not listed below, contact the [Apache Security Team](mailto:security@apache.org?subject=%5BFINDING%5D%20Apache%20project%20name%20here).
+To report a vulnerability in an Apache project that is not listed below, contact the [Apache Security Team](mailto:security@apache.org?subject=Project%20name%20here).
 
 Use the tabs below to jump to projects by their initial. Every project lists a security contact; some also publish a security page and a list of advisories.
 """)
@@ -114,14 +114,13 @@ def project_md_lines(pmc, p):
         # The shared Security Team list handles every project, so name the
         # project in the subject to help routing.
         contact_addr = 'security@apache.org'
-        subject = '[FINDING] %s' % p['name']
     else:
         # A project-specific list already knows which project it is.
         contact_addr = p['contact']
-        subject = '[FINDING]'
+    quoted_subject = quote(display_name(p['name']))
     # Standard mailto: a bare address plus a prefilled subject, so no mail
     # client trips over a non-standard "Name <address>" recipient.
-    contact_href = 'mailto:%s?subject=%s' % (quote(contact_addr, safe='@'), quote(subject))
+    contact_href = 'mailto:%s?subject=%s' % (quote(contact_addr, safe='@'), quoted_subject)
     # Optional logo floated to the card's right (see custom.css). Only projects
     # that publish a logo carry a logo_link in project-coordinates.json; the
     # inline HTML <img> passes through Goldmark (unsafe=true) and the **name**
@@ -219,11 +218,11 @@ layout: single
     project_page.write('# Reporting\n\n')
     project_page.write('Do you want disclose a potential security issue for %s? ' % p['name'])
     project_page.write('Send your report to the ')
-    subject = '[FINDING] %s' % p['name']
+    quoted_subject = quote(display_name(p['name']))
     if not 'contact' in p.keys() or p['contact'] == 'security@apache.org':
-        project_page.write('[Apache Security Team](mailto:security@apache.org?subject=%s).' % quote(subject))
+        project_page.write('[Apache Security Team](mailto:security@apache.org?subject=%s).' % quoted_subject)
     else:
-        project_page.write('[%s Security Team](mailto:%s?subject=%s).' % (p['name'], quote(p['contact']), quote(subject)))
+        project_page.write('[%s Security Team](mailto:%s?subject=%s).' % (p['name'], quote(p['contact'], safe='@'), quoted_subject))
     if models:
         # A PMC that ships several projects publishes one security model per
         # project, so these are listed rather than woven into the sentence.


### PR DESCRIPTION
Support PMCs that ship several projects, each with its own security model, and use Apache Commons as the first real example.

> Stacked on #72. Review/merge that one first; this PR targets `cve-updates-2026-07-17` so its diff shows only the three commits below. Rebase onto `main` once #72 lands.

## Commits

1. **Support PMCs that ship multiple projects** (schema + generator)
   - Rename the schema's `project` def to `pmc`; add a new `project` def with the three fields a shipped project needs (`name`, `security_model_link`, `security_model_source`). A `pmc` extends `project` via `allOf` and gains an optional `projects` list.
   - Because the extension uses `allOf`, the closure keyword changes from `additionalProperties: false` to `unevaluatedProperties: false`.
   - `project-page.py` renders every `security_model_link` (the PMC's own plus one per project) as a list of `<name> security model` links under a `Security model(s)` heading.

2. **Register Apache Commons multi-project security models** (metadata)
   - Point the Commons PMC entry at its new umbrella threat model (`commons.apache.org/threat_model.html`, sourced from the cms-site SVN) instead of the older CVE-listing security page.
   - Add the Commons components that publish a threat model of their own: **Configuration**, **Imaging**, **XML**. Components that only list CVEs or defer to the global Commons security page are left out.

3. **Regenerate project pages for Commons security models** (generated output)

## Result

The Commons entry (overview and per-project page) now lists:

- Apache Commons security model
- Apache Commons Configuration security model
- Apache Commons Imaging security model
- Apache Commons XML security model

Assisted-By: Claude Opus 4.8 (1M context)
