### PR TITLE
Add and correct verified threat-model links in project-coordinates.json

### DIFF
--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -873,8 +873,8 @@
   },
   "knox": {
     "name": "Apache Knox",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/knox/blob/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/knox/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/knox/default.png"

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -160,17 +160,17 @@
     "projects": [
       {
         "name": "Apache Axis2 Java Core",
-        "security_model_link": "https://github.com/apache/axis-axis2-java-core/blob/master/SECURITY.md",
+        "security_model_link": "https://github.com/apache/axis-axis2-java-core/security/policy",
         "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-core/master/SECURITY.md"
       },
       {
         "name": "Apache Axis2 Java Rampart",
-        "security_model_link": "https://github.com/apache/axis-axis2-java-rampart/blob/master/SECURITY.md",
+        "security_model_link": "https://github.com/apache/axis-axis2-java-rampart/security/policy",
         "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-rampart/master/SECURITY.md"
       },
       {
         "name": "Apache Axis2 C Core",
-        "security_model_link": "https://github.com/apache/axis-axis2-c-core/blob/master/SECURITY.md",
+        "security_model_link": "https://github.com/apache/axis-axis2-c-core/security/policy",
         "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-c-core/master/SECURITY.md"
       }
     ]
@@ -526,7 +526,7 @@
   },
   "fineract": {
     "name": "Apache Fineract",
-    "security_model_link": "https://github.com/apache/fineract/blob/develop/SECURITY.md",
+    "security_model_link": "https://github.com/apache/fineract/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/fineract/develop/SECURITY.md",
     "advisory_link": "https://fineract.apache.org/security.html",
     "contact": "security@fineract.apache.org",
@@ -567,7 +567,7 @@
   },
   "freemarker": {
     "name": "Apache FreeMarker",
-    "security_model_link": "https://github.com/apache/freemarker/blob/2.3-gae/SECURITY.md",
+    "security_model_link": "https://github.com/apache/freemarker/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/freemarker/2.3-gae/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
@@ -575,7 +575,7 @@
     "projects": [
       {
         "name": "Apache FreeMarker Online Tester",
-        "security_model_link": "https://github.com/apache/freemarker-online-tester/blob/master/SECURITY.md",
+        "security_model_link": "https://github.com/apache/freemarker-online-tester/security/policy",
         "security_model_source": "https://raw.githubusercontent.com/apache/freemarker-online-tester/master/SECURITY.md"
       }
     ]
@@ -764,7 +764,7 @@
   },
   "impala": {
     "name": "Apache Impala",
-    "security_model_link": "https://github.com/apache/impala/blob/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/impala/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/impala/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
@@ -1156,7 +1156,7 @@
   },
   "parquet": {
     "name": "Apache Parquet",
-    "security_model_link": "https://github.com/apache/parquet-java/blob/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/parquet-java/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/parquet-java/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
@@ -1164,7 +1164,7 @@
   },
   "pdfbox": {
     "name": "Apache PDFBox",
-    "security_model_link": "https://github.com/apache/pdfbox/blob/trunk/SECURITY.md",
+    "security_model_link": "https://github.com/apache/pdfbox/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/pdfbox/trunk/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
@@ -1523,7 +1523,7 @@
   },
   "superset": {
     "name": "Apache Superset",
-    "security_model_link": "https://github.com/apache/superset/blob/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/superset/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/superset/master/SECURITY.md",
     "advisory_link": "https://superset.apache.org/docs/security/cves",
     "contact": "security@superset.apache.org",
@@ -1644,7 +1644,7 @@
   },
   "tomee": {
     "name": "Apache TomEE",
-    "security_model_link": "https://github.com/apache/tomee/blob/main/SECURITY.md",
+    "security_model_link": "https://github.com/apache/tomee/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/tomee/main/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
@@ -1660,7 +1660,7 @@
   },
   "trafficserver": {
     "name": "Apache Traffic Server",
-    "security_model_link": "https://github.com/apache/trafficserver/blob/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/trafficserver/security/policy",
     "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@trafficserver.apache.org",
@@ -1668,7 +1668,7 @@
     "projects": [
       {
         "name": "Apache Traffic Server Ingress Controller",
-        "security_model_link": "https://github.com/apache/trafficserver-ingress-controller/blob/master/SECURITY.md",
+        "security_model_link": "https://github.com/apache/trafficserver-ingress-controller/security/policy",
         "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver-ingress-controller/master/SECURITY.md"
       }
     ]

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -10,8 +10,8 @@
   },
   "activemq": {
     "name": "Apache ActiveMQ",
-    "security_model_link": "https://github.com/apache/activemq/security/policy",
-    "security_model_source": "https://raw.githubusercontent.com/apache/activemq/main/SECURITY.md",
+    "security_model_link": "https://github.com/apache/activemq/blob/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/activemq/refs/heads/main/THREAT_MODEL.md",
     "advisory_link": "https://activemq.apache.org/security-advisories",
     "contact": "security@apache.org",
     "contributing": "https://activemq.apache.org/contributing",
@@ -77,8 +77,8 @@
   },
   "apisix": {
     "name": "Apache APISIX",
-    "security_model_link": "https://github.com/apache/apisix/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/apisix/master/THREAT_MODEL.md",
+    "security_model_link": "https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/apisix/refs/heads/master/docs/en/latest/security-threat-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/apisix/default.png"
@@ -118,7 +118,7 @@
   "artemis": {
     "name": "Apache Artemis",
     "security_model_link": "https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc",
-    "security_model_source": "https://raw.githubusercontent.com/apache/artemis/main/docs/user-manual/threat-model.adoc",
+    "security_model_source": "https://raw.githubusercontent.com/apache/artemis/refs/heads/main/docs/user-manual/threat-model.adoc",
     "advisory_link": "https://artemis.apache.org/components/artemis/security",
     "contact": "security@apache.org",
     "contributing": "https://artemis.apache.org/contributing",
@@ -151,12 +151,29 @@
   },
   "axis": {
     "name": "Apache Axis",
-    "security_model_link": "https://github.com/apache/axis-axis2-java-core/security/policy",
-    "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-core/refs/heads/master/SECURITY.md",
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": null,
-    "logo_link": null
+    "logo_link": null,
+    "projects": [
+      {
+        "name": "Apache Axis2 Java Core",
+        "security_model_link": "https://github.com/apache/axis-axis2-java-core/blob/master/SECURITY.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-core/refs/heads/master/SECURITY.md"
+      },
+      {
+        "name": "Apache Axis2 Java Rampart",
+        "security_model_link": "https://github.com/apache/axis-axis2-java-rampart/blob/master/SECURITY.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-rampart/refs/heads/master/SECURITY.md"
+      },
+      {
+        "name": "Apache Axis2 C Core",
+        "security_model_link": "https://github.com/apache/axis-axis2-c-core/blob/master/SECURITY.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-c-core/refs/heads/master/SECURITY.md"
+      }
+    ]
   },
   "baremaps": {
     "name": "Apache Baremaps",
@@ -201,7 +218,7 @@
   "brpc": {
     "name": "Apache bRPC",
     "security_model_link": "https://github.com/apache/brpc/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/brpc/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/brpc/refs/heads/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://brpc.apache.org/docs/community/community/",
@@ -233,8 +250,9 @@
   },
   "camel": {
     "name": "Apache Camel",
-    "security_model_link": "https://camel.apache.org/manual/security-model.html",
+    "security_model_link": "https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/security-model.adoc",
     "security_model_source": "https://raw.githubusercontent.com/apache/camel/refs/heads/main/docs/user-manual/modules/ROOT/pages/security-model.adoc",
+    "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/camel/default.png"
   },
@@ -248,8 +266,8 @@
   },
   "cassandra": {
     "name": "Apache Cassandra",
-    "security_model_link": "https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html",
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/cassandra/blob/trunk/doc/modules/cassandra/pages/reference/security-model.adoc",
+    "security_model_source": "https://raw.githubusercontent.com/apache/cassandra/refs/heads/trunk/doc/modules/cassandra/pages/reference/security-model.adoc",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://cassandra.apache.org/_/community.html#how-to-contribute",
@@ -435,8 +453,8 @@
   },
   "dolphinscheduler": {
     "name": "Apache DolphinScheduler",
-    "security_model_link": "https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/dolphinscheduler/dev/docs/docs/en/contribute/join/security.md",
+    "security_model_link": "https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/dolphinscheduler/refs/heads/dev/docs/docs/en/contribute/join/security-model.md",
     "advisory_link": null,
     "contact": "security@dolphinscheduler.apache.org",
     "logo_link": "https://www.apache.org/logos/res/dolphinscheduler/default.png"
@@ -508,7 +526,7 @@
   },
   "fineract": {
     "name": "Apache Fineract",
-    "security_model_link": "https://github.com/apache/fineract/security/policy",
+    "security_model_link": "https://github.com/apache/fineract/blob/develop/SECURITY.md",
     "security_model_source": "https://raw.githubusercontent.com/apache/fineract/refs/heads/develop/SECURITY.md",
     "advisory_link": "https://fineract.apache.org/security.html",
     "contact": "security@fineract.apache.org",
@@ -549,11 +567,18 @@
   },
   "freemarker": {
     "name": "Apache FreeMarker",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/freemarker/blob/2.3-gae/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/freemarker/refs/heads/2.3-gae/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
-    "logo_link": "https://www.apache.org/logos/res/freemarker/default.png"
+    "logo_link": "https://www.apache.org/logos/res/freemarker/default.png",
+    "projects": [
+      {
+        "name": "Apache FreeMarker Online Tester",
+        "security_model_link": "https://github.com/apache/freemarker-online-tester/blob/master/SECURITY.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/freemarker-online-tester/refs/heads/master/SECURITY.md"
+      }
+    ]
   },
   "geode": {
     "name": "Apache Geode",
@@ -593,7 +618,14 @@
     "security_model_source": "https://raw.githubusercontent.com/apache/grails-core/refs/heads/8.0.x/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
-    "logo_link": "https://www.apache.org/logos/res/grails/default.png"
+    "logo_link": "https://www.apache.org/logos/res/grails/default.png",
+    "projects": [
+      {
+        "name": "Apache Grails Spring Security",
+        "security_model_link": "https://github.com/apache/grails-spring-security/blob/8.0.x/THREAT_MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/grails-spring-security/refs/heads/8.0.x/THREAT_MODEL.md"
+      }
+    ]
   },
   "gravitino": {
     "name": "Apache Gravitino",
@@ -606,7 +638,7 @@
   "groovy": {
     "name": "Apache Groovy",
     "security_model_link": "https://github.com/apache/groovy/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/groovy/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/groovy/refs/heads/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://groovy.apache.org/#contribute-btn",
@@ -732,8 +764,8 @@
   },
   "impala": {
     "name": "Apache Impala",
-    "security_model_link": "https://github.com/apache/impala/security/policy",
-    "security_model_source": "https://raw.githubusercontent.com/apache/impala/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/impala/blob/master/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/impala/refs/heads/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/impala/default.png"
@@ -756,11 +788,23 @@
   },
   "jackrabbit": {
     "name": "Apache Jackrabbit",
-    "security_model_link": "https://jackrabbit.apache.org/jcr/security-reports.html",
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/jackrabbit/blob/trunk/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit/refs/heads/trunk/THREAT_MODEL.md",
     "advisory_link": "https://jackrabbit.apache.org/jcr/security-reports.html",
     "contact": "security@jackrabbit.apache.org",
-    "logo_link": "https://www.apache.org/logos/res/jackrabbit/default.png"
+    "logo_link": "https://www.apache.org/logos/res/jackrabbit/default.png",
+    "projects": [
+      {
+        "name": "Apache Jackrabbit Oak",
+        "security_model_link": "https://github.com/apache/jackrabbit-oak/blob/trunk/THREAT_MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit-oak/refs/heads/trunk/THREAT_MODEL.md"
+      },
+      {
+        "name": "Apache Jackrabbit FileVault",
+        "security_model_link": "https://github.com/apache/jackrabbit-filevault/blob/master/THREAT_MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit-filevault/refs/heads/master/THREAT_MODEL.md"
+      }
+    ]
   },
   "james": {
     "name": "Apache James",
@@ -773,7 +817,7 @@
   "jena": {
     "name": "Apache Jena",
     "security_model_link": "https://github.com/apache/jena/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/jena/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/jena/refs/heads/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/jena/default.png"
@@ -812,8 +856,8 @@
   },
   "kafka": {
     "name": "Apache Kafka",
-    "security_model_link": "https://kafka.apache.org/project-security.html",
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/kafka/blob/trunk/docs/security/security-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/kafka/refs/heads/trunk/docs/security/security-model.md",
     "advisory_link": "https://kafka.apache.org/cve-list.html",
     "contact": "security@kafka.apache.org",
     "dependency_advisory_triage": "https://github.com/apache/kafka/blob/trunk/gradle/resources/dependencycheck-suppressions.xml",
@@ -1120,8 +1164,8 @@
   },
   "pdfbox": {
     "name": "Apache PDFBox",
-    "security_model_link": "https://pdfbox.apache.org/security.html",
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/pdfbox/blob/trunk/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/pdfbox/refs/heads/trunk/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/pdfbox/default.png"
@@ -1188,7 +1232,14 @@
     "security_model_source": "https://raw.githubusercontent.com/apache/polaris/refs/heads/main/SECURITY-THREAT-MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
-    "logo_link": "https://www.apache.org/logos/res/polaris/default.png"
+    "logo_link": "https://www.apache.org/logos/res/polaris/default.png",
+    "projects": [
+      {
+        "name": "Apache Polaris Tools",
+        "security_model_link": "https://github.com/apache/polaris-tools/blob/main/SECURITY-THREAT-MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/polaris-tools/refs/heads/main/SECURITY-THREAT-MODEL.md"
+      }
+    ]
   },
   "pulsar": {
     "name": "Apache Pulsar",
@@ -1349,7 +1400,7 @@
   },
   "shiro": {
     "name": "Apache Shiro",
-    "security_model_link": "https://shiro.apache.org/security-reports.html",
+    "security_model_link": "https://shiro.apache.org/security-model.html",
     "security_model_source": null,
     "advisory_link": null,
     "contact": "security@shiro.apache.org",
@@ -1390,8 +1441,8 @@
   },
   "solr": {
     "name": "Apache Solr",
-    "security_model_link": "https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity",
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/solr/blob/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/solr/refs/heads/main/THREAT_MODEL.md",
     "advisory_link": "https://solr.apache.org/security.html#recent-cve-reports-for-apache-solr",
     "contact": "security@solr.apache.org",
     "dependency_advisory_triage": "https://solr.apache.org/solr.vex.json",
@@ -1407,7 +1458,7 @@
   },
   "spark": {
     "name": "Apache Spark",
-    "security_model_link": "https://spark.apache.org/security.html",
+    "security_model_link": "https://spark.apache.org/docs/latest/security.html",
     "security_model_source": null,
     "advisory_link": "https://spark.apache.org/security.html",
     "contact": "security@apache.org",
@@ -1472,11 +1523,18 @@
   },
   "superset": {
     "name": "Apache Superset",
-    "security_model_link": "https://github.com/apache/superset/security/policy",
-    "security_model_source": "https://raw.githubusercontent.com/apache/superset/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/superset/blob/master/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/superset/refs/heads/master/SECURITY.md",
     "advisory_link": "https://superset.apache.org/docs/security/cves",
     "contact": "security@superset.apache.org",
-    "logo_link": "https://www.apache.org/logos/res/superset/default.png"
+    "logo_link": "https://www.apache.org/logos/res/superset/default.png",
+    "projects": [
+      {
+        "name": "Apache Superset Kubernetes Operator",
+        "security_model_link": "https://github.com/apache/superset-kubernetes-operator/blob/main/docs/reference/security.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/superset-kubernetes-operator/refs/heads/main/docs/reference/security.md"
+      }
+    ]
   },
   "synapse": {
     "name": "Apache Synapse",
@@ -1520,11 +1578,28 @@
   },
   "teaclave": {
     "name": "Apache Teaclave",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/teaclave/blob/main/docs/security-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/teaclave/refs/heads/main/docs/security-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
-    "logo_link": "https://www.apache.org/logos/res/teaclave/default.png"
+    "logo_link": "https://www.apache.org/logos/res/teaclave/default.png",
+    "projects": [
+      {
+        "name": "Apache Teaclave (Rust Crates)",
+        "security_model_link": "https://github.com/apache/teaclave-crates/blob/main/docs/security-model.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-crates/refs/heads/main/docs/security-model.md"
+      },
+      {
+        "name": "Apache Teaclave TrustZone SDK",
+        "security_model_link": "https://github.com/apache/teaclave-trustzone-sdk/blob/main/docs/security-model.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-trustzone-sdk/refs/heads/main/docs/security-model.md"
+      },
+      {
+        "name": "Apache Teaclave SGX SDK",
+        "security_model_link": "https://github.com/apache/teaclave-sgx-sdk/blob/main/docs/security-model.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-sgx-sdk/refs/heads/main/docs/security-model.md"
+      }
+    ]
   },
   "tez": {
     "name": "Apache Tez",
@@ -1537,7 +1612,7 @@
   "thrift": {
     "name": "Apache Thrift",
     "security_model_link": "https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/thrift/master/doc/thrift-threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/thrift/refs/heads/master/doc/thrift-threat-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/thrift/default.png"
@@ -1552,15 +1627,15 @@
   },
   "tinkerpop": {
     "name": "Apache TinkerPop",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/tinkerpop/blob/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/tinkerpop/refs/heads/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tinkerpop/default.png"
   },
   "tomcat": {
     "name": "Apache Tomcat",
-    "security_model_link": "https://tomcat.apache.org/security.html",
+    "security_model_link": "https://tomcat.apache.org/security-model.html",
     "security_model_source": null,
     "advisory_link": "https://tomcat.apache.org/security.html",
     "contact": "security@tomcat.apache.org",
@@ -1569,8 +1644,8 @@
   },
   "tomee": {
     "name": "Apache TomEE",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/tomee/blob/main/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/tomee/refs/heads/main/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tomee/default.png"
@@ -1585,11 +1660,18 @@
   },
   "trafficserver": {
     "name": "Apache Traffic Server",
-    "security_model_link": "https://github.com/apache/trafficserver/security/policy",
-    "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver/master/SECURITY.md",
+    "security_model_link": "https://github.com/apache/trafficserver/blob/master/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver/refs/heads/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@trafficserver.apache.org",
-    "logo_link": "https://www.apache.org/logos/res/trafficserver/default.png"
+    "logo_link": "https://www.apache.org/logos/res/trafficserver/default.png",
+    "projects": [
+      {
+        "name": "Apache Traffic Server Ingress Controller",
+        "security_model_link": "https://github.com/apache/trafficserver-ingress-controller/blob/master/SECURITY.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver-ingress-controller/refs/heads/master/SECURITY.md"
+      }
+    ]
   },
   "trafodion": {
     "name": "Apache Trafodion",
@@ -1697,11 +1779,28 @@
   },
   "ws": {
     "name": "Apache Web Services",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/ws-wss4j/blob/master/THREAT-MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/ws-wss4j/refs/heads/master/THREAT-MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
-    "logo_link": "https://www.apache.org/logos/res/ws/default.png"
+    "logo_link": "https://www.apache.org/logos/res/ws/default.png",
+    "projects": [
+      {
+        "name": "Apache Axiom",
+        "security_model_link": "https://github.com/apache/ws-axiom/blob/master/THREAT-MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/ws-axiom/refs/heads/master/THREAT-MODEL.md"
+      },
+      {
+        "name": "Apache XmlSchema",
+        "security_model_link": "https://github.com/apache/ws-xmlschema/blob/master/THREAT-MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/ws-xmlschema/refs/heads/master/THREAT-MODEL.md"
+      },
+      {
+        "name": "Apache Neethi",
+        "security_model_link": "https://github.com/apache/ws-neethi/blob/master/THREAT-MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/ws-neethi/refs/heads/master/THREAT-MODEL.md"
+      }
+    ]
   },
   "xalan": {
     "name": "Apache Xalan",

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -1779,8 +1779,8 @@
   },
   "ws": {
     "name": "Apache Web Services",
-    "security_model_link": "https://github.com/apache/ws-wss4j/blob/master/THREAT-MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/ws-wss4j/master/THREAT-MODEL.md",
+    "security_model_link": null,
+    "security_model_source": null,
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/ws/default.png",
@@ -1799,6 +1799,11 @@
         "name": "Apache Neethi",
         "security_model_link": "https://github.com/apache/ws-neethi/blob/master/THREAT-MODEL.md",
         "security_model_source": "https://raw.githubusercontent.com/apache/ws-neethi/master/THREAT-MODEL.md"
+      },
+      {
+        "name": "Apache WSS4J",
+        "security_model_link": "https://github.com/apache/ws-wss4j/blob/master/THREAT-MODEL.md",
+        "security_model_source": "https://raw.githubusercontent.com/apache/ws-wss4j/master/THREAT-MODEL.md"
       }
     ]
   },

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -250,7 +250,7 @@
   },
   "camel": {
     "name": "Apache Camel",
-    "security_model_link": "https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/security-model.adoc",
+    "security_model_link": "https://camel.apache.org/manual/security-model.html",
     "security_model_source": "https://raw.githubusercontent.com/apache/camel/main/docs/user-manual/modules/ROOT/pages/security-model.adoc",
     "advisory_link": null,
     "contact": "security@apache.org",

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -11,7 +11,7 @@
   "activemq": {
     "name": "Apache ActiveMQ",
     "security_model_link": "https://github.com/apache/activemq/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/activemq/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/activemq/main/THREAT_MODEL.md",
     "advisory_link": "https://activemq.apache.org/security-advisories",
     "contact": "security@apache.org",
     "contributing": "https://activemq.apache.org/contributing",
@@ -78,7 +78,7 @@
   "apisix": {
     "name": "Apache APISIX",
     "security_model_link": "https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/apisix/refs/heads/master/docs/en/latest/security-threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/apisix/master/docs/en/latest/security-threat-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/apisix/default.png"
@@ -118,7 +118,7 @@
   "artemis": {
     "name": "Apache Artemis",
     "security_model_link": "https://github.com/apache/artemis/blob/main/docs/user-manual/threat-model.adoc",
-    "security_model_source": "https://raw.githubusercontent.com/apache/artemis/refs/heads/main/docs/user-manual/threat-model.adoc",
+    "security_model_source": "https://raw.githubusercontent.com/apache/artemis/main/docs/user-manual/threat-model.adoc",
     "advisory_link": "https://artemis.apache.org/components/artemis/security",
     "contact": "security@apache.org",
     "contributing": "https://artemis.apache.org/contributing",
@@ -143,7 +143,7 @@
   "avro": {
     "name": "Apache Avro",
     "security_model_link": "https://avro.apache.org/project/security/",
-    "security_model_source": "https://raw.githubusercontent.com/apache/avro/refs/heads/main/doc/content/en/project/Security/_index.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/avro/main/doc/content/en/project/Security/_index.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://avro.apache.org/community/",
@@ -161,17 +161,17 @@
       {
         "name": "Apache Axis2 Java Core",
         "security_model_link": "https://github.com/apache/axis-axis2-java-core/blob/master/SECURITY.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-core/refs/heads/master/SECURITY.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-core/master/SECURITY.md"
       },
       {
         "name": "Apache Axis2 Java Rampart",
         "security_model_link": "https://github.com/apache/axis-axis2-java-rampart/blob/master/SECURITY.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-rampart/refs/heads/master/SECURITY.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-java-rampart/master/SECURITY.md"
       },
       {
         "name": "Apache Axis2 C Core",
         "security_model_link": "https://github.com/apache/axis-axis2-c-core/blob/master/SECURITY.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-c-core/refs/heads/master/SECURITY.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/axis-axis2-c-core/master/SECURITY.md"
       }
     ]
   },
@@ -218,7 +218,7 @@
   "brpc": {
     "name": "Apache bRPC",
     "security_model_link": "https://github.com/apache/brpc/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/brpc/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/brpc/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://brpc.apache.org/docs/community/community/",
@@ -251,7 +251,7 @@
   "camel": {
     "name": "Apache Camel",
     "security_model_link": "https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/security-model.adoc",
-    "security_model_source": "https://raw.githubusercontent.com/apache/camel/refs/heads/main/docs/user-manual/modules/ROOT/pages/security-model.adoc",
+    "security_model_source": "https://raw.githubusercontent.com/apache/camel/main/docs/user-manual/modules/ROOT/pages/security-model.adoc",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/camel/default.png"
@@ -267,7 +267,7 @@
   "cassandra": {
     "name": "Apache Cassandra",
     "security_model_link": "https://github.com/apache/cassandra/blob/trunk/doc/modules/cassandra/pages/reference/security-model.adoc",
-    "security_model_source": "https://raw.githubusercontent.com/apache/cassandra/refs/heads/trunk/doc/modules/cassandra/pages/reference/security-model.adoc",
+    "security_model_source": "https://raw.githubusercontent.com/apache/cassandra/trunk/doc/modules/cassandra/pages/reference/security-model.adoc",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://cassandra.apache.org/_/community.html#how-to-contribute",
@@ -308,7 +308,7 @@
   "cloudstack": {
     "name": "Apache CloudStack",
     "security_model_link": "https://github.com/apache/cloudstack/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/cloudstack/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/cloudstack/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://cloudstack.apache.org/contribute",
@@ -325,17 +325,17 @@
       {
         "name": "Apache Commons Configuration",
         "security_model_link": "https://commons.apache.org/proper/commons-configuration/security.html",
-        "security_model_source": "https://raw.githubusercontent.com/apache/commons-configuration/refs/heads/master/src/site/xdoc/security.xml"
+        "security_model_source": "https://raw.githubusercontent.com/apache/commons-configuration/master/src/site/xdoc/security.xml"
       },
       {
         "name": "Apache Commons Imaging",
         "security_model_link": "https://commons.apache.org/proper/commons-imaging/security.html",
-        "security_model_source": "https://raw.githubusercontent.com/apache/commons-imaging/refs/heads/master/src/site/xdoc/security.xml"
+        "security_model_source": "https://raw.githubusercontent.com/apache/commons-imaging/master/src/site/xdoc/security.xml"
       },
       {
         "name": "Apache Commons XML",
         "security_model_link": "https://commons.apache.org/sandbox/commons-xml/threat_model.html",
-        "security_model_source": "https://raw.githubusercontent.com/apache/commons-xml/refs/heads/main/src/site/markdown/threat_model.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/commons-xml/main/src/site/markdown/threat_model.md"
       }
     ]
   },
@@ -358,7 +358,7 @@
   "creadur": {
     "name": "Apache Creadur",
     "security_model_link": "https://github.com/apache/creadur-rat/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/creadur-rat/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/creadur-rat/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/creadur/default.png"
@@ -382,7 +382,7 @@
   "cxf": {
     "name": "Apache CXF",
     "security_model_link": "https://github.com/apache/cxf/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/cxf/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/cxf/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/cxf/default.png"
@@ -422,7 +422,7 @@
   "db": {
     "name": "Apache DB",
     "security_model_link": "https://github.com/apache/db-jdo/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/db-jdo/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/db-jdo/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/db/default.png"
@@ -446,7 +446,7 @@
   "directory": {
     "name": "Apache Directory",
     "security_model_link": "https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/directory-server/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/directory-server/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/directory/default.png"
@@ -454,7 +454,7 @@
   "dolphinscheduler": {
     "name": "Apache DolphinScheduler",
     "security_model_link": "https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/dolphinscheduler/refs/heads/dev/docs/docs/en/contribute/join/security-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/dolphinscheduler/dev/docs/docs/en/contribute/join/security-model.md",
     "advisory_link": null,
     "contact": "security@dolphinscheduler.apache.org",
     "logo_link": "https://www.apache.org/logos/res/dolphinscheduler/default.png"
@@ -462,7 +462,7 @@
   "doris": {
     "name": "Apache Doris",
     "security_model_link": "https://github.com/apache/doris/blob/master/threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/doris/refs/heads/master/threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/doris/master/threat-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/doris/default.png"
@@ -470,7 +470,7 @@
   "drill": {
     "name": "Apache Drill",
     "security_model_link": "https://github.com/apache/drill/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/drill/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/drill/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/drill/default.png"
@@ -486,7 +486,7 @@
   "dubbo": {
     "name": "Apache Dubbo",
     "security_model_link": "https://github.com/apache/dubbo/blob/3.3/docs/threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/dubbo/refs/heads/3.3/docs/threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/dubbo/3.3/docs/threat-model.md",
     "advisory_link": null,
     "contact": "security@dubbo.apache.org",
     "logo_link": "https://www.apache.org/logos/res/dubbo/default.png"
@@ -527,7 +527,7 @@
   "fineract": {
     "name": "Apache Fineract",
     "security_model_link": "https://github.com/apache/fineract/blob/develop/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/fineract/refs/heads/develop/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/fineract/develop/SECURITY.md",
     "advisory_link": "https://fineract.apache.org/security.html",
     "contact": "security@fineract.apache.org",
     "logo_link": "https://www.apache.org/logos/res/fineract/default.png"
@@ -560,7 +560,7 @@
   "fory": {
     "name": "Apache Fory",
     "security_model_link": "https://github.com/apache/fory/blob/main/docs/security/threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/fory/refs/heads/main/docs/security/threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/fory/main/docs/security/threat-model.md",
     "advisory_link": "https://fory.apache.org/security/",
     "contact": "security@apache.org",
     "logo_link": null
@@ -568,7 +568,7 @@
   "freemarker": {
     "name": "Apache FreeMarker",
     "security_model_link": "https://github.com/apache/freemarker/blob/2.3-gae/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/freemarker/refs/heads/2.3-gae/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/freemarker/2.3-gae/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/freemarker/default.png",
@@ -576,7 +576,7 @@
       {
         "name": "Apache FreeMarker Online Tester",
         "security_model_link": "https://github.com/apache/freemarker-online-tester/blob/master/SECURITY.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/freemarker-online-tester/refs/heads/master/SECURITY.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/freemarker-online-tester/master/SECURITY.md"
       }
     ]
   },
@@ -615,7 +615,7 @@
   "grails": {
     "name": "Apache Grails",
     "security_model_link": "https://github.com/apache/grails-core/blob/8.0.x/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/grails-core/refs/heads/8.0.x/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/grails-core/8.0.x/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/grails/default.png",
@@ -623,7 +623,7 @@
       {
         "name": "Apache Grails Spring Security",
         "security_model_link": "https://github.com/apache/grails-spring-security/blob/8.0.x/THREAT_MODEL.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/grails-spring-security/refs/heads/8.0.x/THREAT_MODEL.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/grails-spring-security/8.0.x/THREAT_MODEL.md"
       }
     ]
   },
@@ -638,7 +638,7 @@
   "groovy": {
     "name": "Apache Groovy",
     "security_model_link": "https://github.com/apache/groovy/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/groovy/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/groovy/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://groovy.apache.org/#contribute-btn",
@@ -663,7 +663,7 @@
   "hadoop": {
     "name": "Apache Hadoop",
     "security_model_link": "https://github.com/apache/hadoop/security/policy",
-    "security_model_source": "https://raw.githubusercontent.com/apache/hadoop/refs/heads/trunk/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/hadoop/trunk/SECURITY.md",
     "advisory_link": "https://hadoop.apache.org/cve_list.html",
     "contact": "security@hadoop.apache.org",
     "logo_link": "https://www.apache.org/logos/res/hadoop/default.png"
@@ -680,7 +680,7 @@
   "helix": {
     "name": "Apache Helix",
     "security_model_link": "https://github.com/apache/helix/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/helix/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/helix/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/helix/default.png"
@@ -697,7 +697,7 @@
   "hive": {
     "name": "Apache Hive",
     "security_model_link": "https://github.com/apache/hive/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/hive/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/hive/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@hive.apache.org",
     "logo_link": "https://www.apache.org/logos/res/hive/default.png"
@@ -705,7 +705,7 @@
   "hop": {
     "name": "Apache Hop",
     "security_model_link": "https://github.com/apache/hop/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/hop/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/hop/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/hop/default.png"
@@ -747,7 +747,7 @@
   "iceberg": {
     "name": "Apache Iceberg",
     "security_model_link": "https://github.com/apache/iceberg/blob/main/SECURITY-THREAT-MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/iceberg/refs/heads/main/SECURITY-THREAT-MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/iceberg/main/SECURITY-THREAT-MODEL.md",
     "advisory_link": null,
     "contact": "security@iceberg.apache.org",
     "contributing": "https://iceberg.apache.org/community/",
@@ -765,7 +765,7 @@
   "impala": {
     "name": "Apache Impala",
     "security_model_link": "https://github.com/apache/impala/blob/master/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/impala/refs/heads/master/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/impala/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/impala/default.png"
@@ -781,7 +781,7 @@
   "iotdb": {
     "name": "Apache IoTDB",
     "security_model_link": "https://github.com/apache/iotdb/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/iotdb/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/iotdb/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/iotdb/default.png"
@@ -789,7 +789,7 @@
   "jackrabbit": {
     "name": "Apache Jackrabbit",
     "security_model_link": "https://github.com/apache/jackrabbit/blob/trunk/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit/refs/heads/trunk/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit/trunk/THREAT_MODEL.md",
     "advisory_link": "https://jackrabbit.apache.org/jcr/security-reports.html",
     "contact": "security@jackrabbit.apache.org",
     "logo_link": "https://www.apache.org/logos/res/jackrabbit/default.png",
@@ -797,12 +797,12 @@
       {
         "name": "Apache Jackrabbit Oak",
         "security_model_link": "https://github.com/apache/jackrabbit-oak/blob/trunk/THREAT_MODEL.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit-oak/refs/heads/trunk/THREAT_MODEL.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit-oak/trunk/THREAT_MODEL.md"
       },
       {
         "name": "Apache Jackrabbit FileVault",
         "security_model_link": "https://github.com/apache/jackrabbit-filevault/blob/master/THREAT_MODEL.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit-filevault/refs/heads/master/THREAT_MODEL.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/jackrabbit-filevault/master/THREAT_MODEL.md"
       }
     ]
   },
@@ -817,7 +817,7 @@
   "jena": {
     "name": "Apache Jena",
     "security_model_link": "https://github.com/apache/jena/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/jena/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/jena/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/jena/default.png"
@@ -825,7 +825,7 @@
   "jmeter": {
     "name": "Apache JMeter",
     "security_model_link": "https://github.com/apache/jmeter/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/jmeter/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/jmeter/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/jmeter/default.png"
@@ -841,7 +841,7 @@
   "jspwiki": {
     "name": "Apache JSPWiki",
     "security_model_link": "https://github.com/apache/jspwiki/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/jspwiki/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/jspwiki/master/THREAT_MODEL.md",
     "advisory_link": "https://jspwiki-wiki.apache.org/Wiki.jsp?page=CVE",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/jspwiki/default.png"
@@ -857,7 +857,7 @@
   "kafka": {
     "name": "Apache Kafka",
     "security_model_link": "https://github.com/apache/kafka/blob/trunk/docs/security/security-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/kafka/refs/heads/trunk/docs/security/security-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/kafka/trunk/docs/security/security-model.md",
     "advisory_link": "https://kafka.apache.org/cve-list.html",
     "contact": "security@kafka.apache.org",
     "dependency_advisory_triage": "https://github.com/apache/kafka/blob/trunk/gradle/resources/dependencycheck-suppressions.xml",
@@ -882,7 +882,7 @@
   "kudu": {
     "name": "Apache Kudu",
     "security_model_link": "https://github.com/apache/kudu/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/kudu/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/kudu/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/kudu/default.png"
@@ -890,7 +890,7 @@
   "kvrocks": {
     "name": "Apache Kvrocks",
     "security_model_link": "https://github.com/apache/kvrocks/blob/unstable/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/kvrocks/refs/heads/unstable/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/kvrocks/unstable/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/kvrocks/default.png"
@@ -939,7 +939,7 @@
   "logging": {
     "name": "Apache Logging",
     "security_model_link": "https://logging.apache.org/security.html",
-    "security_model_source": "https://raw.githubusercontent.com/apache/logging-site/refs/heads/main/src/site/antora/modules/ROOT/pages/_threat-model-common.adoc",
+    "security_model_source": "https://raw.githubusercontent.com/apache/logging-site/main/src/site/antora/modules/ROOT/pages/_threat-model-common.adoc",
     "advisory_link": "https://logging.apache.org/security.html",
     "contact": "security@logging.apache.org",
     "logo_link": null
@@ -971,7 +971,7 @@
   "magpie": {
     "name": "Apache Magpie",
     "security_model_link": "https://github.com/apache/magpie/blob/main/docs/security/threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/magpie/refs/heads/main/docs/security/threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/magpie/main/docs/security/threat-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/magpie/default.png"
@@ -995,7 +995,7 @@
   "maven": {
     "name": "Apache Maven",
     "security_model_link": "https://github.com/apache/maven/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/maven/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/maven/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "contributing": "https://maven.apache.org/developers/index.html",
@@ -1052,7 +1052,7 @@
   "nutch": {
     "name": "Apache Nutch",
     "security_model_link": "https://github.com/apache/nutch/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/nutch/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/nutch/master/THREAT_MODEL.md",
     "advisory_link": "https://nutch.apache.org/documentation/security/#nutch-cve-list",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/nutch/default.png"
@@ -1132,7 +1132,7 @@
   "orc": {
     "name": "Apache ORC",
     "security_model_link": "https://orc.apache.org/security/",
-    "security_model_source": "https://raw.githubusercontent.com/apache/orc/refs/heads/main/site/security/index.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/orc/main/site/security/index.md",
     "advisory_link": "https://orc.apache.org/security/",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/orc/default.png"
@@ -1140,7 +1140,7 @@
   "ozone": {
     "name": "Apache Ozone",
     "security_model_link": "https://github.com/apache/ozone/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/ozone/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/ozone/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@ozone.apache.org",
     "contributing": "https://ozone.apache.org/community/how-to-contribute",
@@ -1157,7 +1157,7 @@
   "parquet": {
     "name": "Apache Parquet",
     "security_model_link": "https://github.com/apache/parquet-java/blob/master/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/parquet-java/refs/heads/master/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/parquet-java/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/parquet/default.png"
@@ -1165,7 +1165,7 @@
   "pdfbox": {
     "name": "Apache PDFBox",
     "security_model_link": "https://github.com/apache/pdfbox/blob/trunk/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/pdfbox/refs/heads/trunk/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/pdfbox/trunk/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/pdfbox/default.png"
@@ -1213,7 +1213,7 @@
   "plc4x": {
     "name": "Apache PLC4X",
     "security_model_link": "https://github.com/apache/plc4x/blob/develop/THREAT-MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/plc4x/refs/heads/develop/THREAT-MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/plc4x/develop/THREAT-MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/plc4x/default.png"
@@ -1229,7 +1229,7 @@
   "polaris": {
     "name": "Apache Polaris",
     "security_model_link": "https://github.com/apache/polaris/blob/main/SECURITY-THREAT-MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/polaris/refs/heads/main/SECURITY-THREAT-MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/polaris/main/SECURITY-THREAT-MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/polaris/default.png",
@@ -1237,7 +1237,7 @@
       {
         "name": "Apache Polaris Tools",
         "security_model_link": "https://github.com/apache/polaris-tools/blob/main/SECURITY-THREAT-MODEL.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/polaris-tools/refs/heads/main/SECURITY-THREAT-MODEL.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/polaris-tools/main/SECURITY-THREAT-MODEL.md"
       }
     ]
   },
@@ -1261,7 +1261,7 @@
   "ranger": {
     "name": "Apache Ranger",
     "security_model_link": "https://github.com/apache/ranger/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/ranger/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/ranger/master/THREAT_MODEL.md",
     "advisory_link": "https://cwiki.apache.org/confluence/display/RANGER/Vulnerabilities+found+in+Ranger",
     "contact": "security@apache.org",
     "contributing": "https://rocketmq.apache.org/docs/contributionGuide/01how-to-contribute",
@@ -1319,7 +1319,7 @@
   "santuario": {
     "name": "Apache Santuario",
     "security_model_link": "https://github.com/apache/santuario-xml-security-java/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/santuario-xml-security-java/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/santuario-xml-security-java/main/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/santuario/default.png"
@@ -1393,7 +1393,7 @@
   "shenyu": {
     "name": "Apache ShenYu",
     "security_model_link": "https://github.com/apache/shenyu/blob/master/SECURITY_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/shenyu/refs/heads/master/SECURITY_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/shenyu/master/SECURITY_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/shenyu/default.png"
@@ -1434,7 +1434,7 @@
   "sling": {
     "name": "Apache Sling",
     "security_model_link": "https://github.com/apache/sling/blob/master/docs/threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/sling/refs/heads/master/docs/threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/sling/master/docs/threat-model.md",
     "advisory_link": null,
     "contact": "security@sling.apache.org",
     "logo_link": "https://www.apache.org/logos/res/sling/default.png"
@@ -1442,7 +1442,7 @@
   "solr": {
     "name": "Apache Solr",
     "security_model_link": "https://github.com/apache/solr/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/solr/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/solr/main/THREAT_MODEL.md",
     "advisory_link": "https://solr.apache.org/security.html#recent-cve-reports-for-apache-solr",
     "contact": "security@solr.apache.org",
     "dependency_advisory_triage": "https://solr.apache.org/solr.vex.json",
@@ -1500,7 +1500,7 @@
   "streampipes": {
     "name": "Apache StreamPipes",
     "security_model_link": "https://github.com/apache/streampipes/blob/dev/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/streampipes/refs/heads/dev/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/streampipes/dev/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/streampipes/default.png"
@@ -1508,7 +1508,7 @@
   "struts": {
     "name": "Apache Struts",
     "security_model_link": "https://github.com/apache/struts/blob/main/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/struts/refs/heads/main/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/struts/main/THREAT_MODEL.md",
     "advisory_link": "https://cwiki.apache.org/confluence/display/WW/Security+Bulletins",
     "contact": "security@struts.apache.org",
     "logo_link": "https://www.apache.org/logos/res/struts/default.png"
@@ -1524,7 +1524,7 @@
   "superset": {
     "name": "Apache Superset",
     "security_model_link": "https://github.com/apache/superset/blob/master/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/superset/refs/heads/master/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/superset/master/SECURITY.md",
     "advisory_link": "https://superset.apache.org/docs/security/cves",
     "contact": "security@superset.apache.org",
     "logo_link": "https://www.apache.org/logos/res/superset/default.png",
@@ -1532,14 +1532,14 @@
       {
         "name": "Apache Superset Kubernetes Operator",
         "security_model_link": "https://github.com/apache/superset-kubernetes-operator/blob/main/docs/reference/security.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/superset-kubernetes-operator/refs/heads/main/docs/reference/security.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/superset-kubernetes-operator/main/docs/reference/security.md"
       }
     ]
   },
   "synapse": {
     "name": "Apache Synapse",
     "security_model_link": "https://github.com/apache/synapse/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/synapse/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/synapse/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/synapse/default.png"
@@ -1563,7 +1563,7 @@
   "tapestry": {
     "name": "Apache Tapestry",
     "security_model_link": "https://github.com/apache/tapestry-5/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/tapestry-5/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/tapestry-5/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tapestry/default.png"
@@ -1579,7 +1579,7 @@
   "teaclave": {
     "name": "Apache Teaclave",
     "security_model_link": "https://github.com/apache/teaclave/blob/main/docs/security-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/teaclave/refs/heads/main/docs/security-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/teaclave/main/docs/security-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/teaclave/default.png",
@@ -1587,17 +1587,17 @@
       {
         "name": "Apache Teaclave (Rust Crates)",
         "security_model_link": "https://github.com/apache/teaclave-crates/blob/main/docs/security-model.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-crates/refs/heads/main/docs/security-model.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-crates/main/docs/security-model.md"
       },
       {
         "name": "Apache Teaclave TrustZone SDK",
         "security_model_link": "https://github.com/apache/teaclave-trustzone-sdk/blob/main/docs/security-model.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-trustzone-sdk/refs/heads/main/docs/security-model.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-trustzone-sdk/main/docs/security-model.md"
       },
       {
         "name": "Apache Teaclave SGX SDK",
         "security_model_link": "https://github.com/apache/teaclave-sgx-sdk/blob/main/docs/security-model.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-sgx-sdk/refs/heads/main/docs/security-model.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/teaclave-sgx-sdk/main/docs/security-model.md"
       }
     ]
   },
@@ -1612,7 +1612,7 @@
   "thrift": {
     "name": "Apache Thrift",
     "security_model_link": "https://github.com/apache/thrift/blob/master/doc/thrift-threat-model.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/thrift/refs/heads/master/doc/thrift-threat-model.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/thrift/master/doc/thrift-threat-model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/thrift/default.png"
@@ -1628,7 +1628,7 @@
   "tinkerpop": {
     "name": "Apache TinkerPop",
     "security_model_link": "https://github.com/apache/tinkerpop/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/tinkerpop/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/tinkerpop/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tinkerpop/default.png"
@@ -1645,7 +1645,7 @@
   "tomee": {
     "name": "Apache TomEE",
     "security_model_link": "https://github.com/apache/tomee/blob/main/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/tomee/refs/heads/main/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/tomee/main/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/tomee/default.png"
@@ -1661,7 +1661,7 @@
   "trafficserver": {
     "name": "Apache Traffic Server",
     "security_model_link": "https://github.com/apache/trafficserver/blob/master/SECURITY.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver/refs/heads/master/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@trafficserver.apache.org",
     "logo_link": "https://www.apache.org/logos/res/trafficserver/default.png",
@@ -1669,7 +1669,7 @@
       {
         "name": "Apache Traffic Server Ingress Controller",
         "security_model_link": "https://github.com/apache/trafficserver-ingress-controller/blob/master/SECURITY.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver-ingress-controller/refs/heads/master/SECURITY.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/trafficserver-ingress-controller/master/SECURITY.md"
       }
     ]
   },
@@ -1732,7 +1732,7 @@
   "unomi": {
     "name": "Apache Unomi",
     "security_model_link": "https://github.com/apache/unomi/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/unomi/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/unomi/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/unomi/default.png"
@@ -1780,7 +1780,7 @@
   "ws": {
     "name": "Apache Web Services",
     "security_model_link": "https://github.com/apache/ws-wss4j/blob/master/THREAT-MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/ws-wss4j/refs/heads/master/THREAT-MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/ws-wss4j/master/THREAT-MODEL.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/ws/default.png",
@@ -1788,17 +1788,17 @@
       {
         "name": "Apache Axiom",
         "security_model_link": "https://github.com/apache/ws-axiom/blob/master/THREAT-MODEL.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/ws-axiom/refs/heads/master/THREAT-MODEL.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/ws-axiom/master/THREAT-MODEL.md"
       },
       {
         "name": "Apache XmlSchema",
         "security_model_link": "https://github.com/apache/ws-xmlschema/blob/master/THREAT-MODEL.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/ws-xmlschema/refs/heads/master/THREAT-MODEL.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/ws-xmlschema/master/THREAT-MODEL.md"
       },
       {
         "name": "Apache Neethi",
         "security_model_link": "https://github.com/apache/ws-neethi/blob/master/THREAT-MODEL.md",
-        "security_model_source": "https://raw.githubusercontent.com/apache/ws-neethi/refs/heads/master/THREAT-MODEL.md"
+        "security_model_source": "https://raw.githubusercontent.com/apache/ws-neethi/master/THREAT-MODEL.md"
       }
     ]
   },
@@ -1845,7 +1845,7 @@
   "zeppelin": {
     "name": "Apache Zeppelin",
     "security_model_link": "https://github.com/apache/zeppelin/blob/master/THREAT_MODEL.md",
-    "security_model_source": "https://raw.githubusercontent.com/apache/zeppelin/refs/heads/master/THREAT_MODEL.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/zeppelin/master/THREAT_MODEL.md",
     "advisory_link": null,
     "contact": "security@zeppelin.apache.org",
     "logo_link": "https://www.apache.org/logos/res/zeppelin/default.png"


### PR DESCRIPTION
Populates and corrects `security_model_link` / `security_model_source` for 66 PMCs whose threat models the ASF Security team has verified, and adds Commons-style `projects[]` arrays for 9 multi-repo PMCs (`axis`, `freemarker`, `grails`, `jackrabbit`, `polaris`, `superset`, `teaclave`, `trafficserver`, `ws`).

Every URL was **deterministically verified to resolve**: 72 GitHub files via the contents API and 9 project-site pages.

Notable fixes to stale/incorrect entries:
- `apisix` pointed at a root `THREAT_MODEL.md` that does not exist — the model lives under `docs/en/latest/security-threat-model.md`.
- `activemq`, `fineract`, `impala`, `superset`, `trafficserver` pointed at GitHub's `/security/policy` tab rather than the actual model file.
- `camel`, `cassandra`, `dolphinscheduler`, `jackrabbit`, `kafka`, `pdfbox`, `shiro`, `solr`, `spark`, `tomcat` pointed at CVE-list / disclosure-policy pages rather than the threat model.

Also adds `advisory_link: null` to the `camel` entry so the file validates against `project-coordinates.schema.json` (pre-existing gap).