### PR TITLE
Add Calcite threat model

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -203,6 +203,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=Calcite)
   - Advisories (experimental):\
     [security.apache.org](/projects/calcite/)
+  - Security model:
+    - [Apache Calcite security model](https://calcite.apache.org/docs/security_threat_model.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/camel/default.png" alt="" loading="lazy"> **Apache Camel**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=Camel)

--- a/content/projects/calcite/_index.md
+++ b/content/projects/calcite/_index.md
@@ -8,9 +8,14 @@ layout: single
 
 Do you want disclose a potential security issue for Apache Calcite? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Calcite).
 
+You can read more about the security policy on:
+
+- [Apache Calcite security model](https://calcite.apache.org/docs/security_threat_model.html)
+
+
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## A user-controled model can load arbitrary classes, leading to code execution ## { #CVE-2026-46718 }

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -242,8 +242,8 @@
   },
   "calcite": {
     "name": "Apache Calcite",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://calcite.apache.org/docs/security_threat_model.html",
+    "security_model_source": "https://raw.githubusercontent.com/apache/calcite/main/site/_docs/security_threat_model.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/calcite/default.png"


### PR DESCRIPTION
Adds a reference to Calcite threat model on `security.apache.org`.

The model was introduced in apache/calcite#5115.

> [!NOTE]
> The threat model hasn't been published yet on `calcite.apache.org`, this PR will be merged once the threat model is live.