### PR TITLE
Clarify reporting instructions in report-code.md

### DIFF
--- a/content/report-code.md
+++ b/content/report-code.md
@@ -5,19 +5,55 @@ description: We strongly encourage you to report potential security vulnerabilit
 
 We warmly welcome reports of potential security vulnerabilities in our codebases.
 
-**Only use the security contacts to report undisclosed security vulnerabilities in Apache projects and manage the process of fixing such vulnerabilities. We cannot accept regular bug reports or other security-related queries at these addresses. We will ignore mail sent to these addresses that does not relate to an undisclosed security problem in an Apache project.**
+Only use the security contacts to report **undisclosed security vulnerabilities in ASF projects**
+and manage the process of fixing such vulnerabilities.
+In particular, this means that:
 
-Note that results from source code security analysis tools are not accepted without additional analysis showing the problem indeed violates the projects' security model, as such tools commonly produce a significant amount of false positives.
+* Your report must concern a **security vulnerability**.
+  We cannot accept regular bug reports, support requests, or other security-related queries at these addresses.
+* The vulnerability must be **undisclosed**.
+  A vulnerability with a CVE number is in most cases already publicly disclosed by the ASF itself.
+  In particular, do not forward security scanner findings that report an ASF project as affected by a known CVE.
+* The vulnerability must affect an **ASF project**.
+  If it affects a dependency of an ASF project instead,
+  see [Reporting security issues in dependencies](/report-dependency).
 
-A security vulnerability is a bug that breaks reasonable expectations of the
-project in a way that affects confidentiality, integrity or availability. Some
-projects have published a 'Security Model' to clarify which guarantees can be
-expected. You can find the security model pages, as well as the email address
-you can use to report potential vulnerabilities, [here](/projects).
+We will ignore mail sent to these addresses
+that does not meet these requirements.
 
-Please send one plain-text, unencrypted, email for each vulnerability you are reporting to [security@apache.org](mailto:security@apache.org). We will reject your report and ask you to resubmit it if you send it as an image, movie, HTML, Markdown, or PDF attachment when you could as easily describe it with plain text.
-By sending your report to this address you agree that information from this report
-may be made public after triage (for invalid issues) or after the release of the fix,
+A **security vulnerability** is a bug that breaks reasonable expectations of the project
+in a way that affects confidentiality, integrity, or availability.
+Some projects have published a 'Security Model'
+to clarify which guarantees can be expected.
+You can find the security model pages on the [projects overview](/projects).
+Note that results from source code security analysis tools are not accepted without additional analysis
+showing that the problem indeed violates the project's security model,
+as such tools commonly produce a significant amount of false positives.
+
+Send your report to the project's security address
+listed on the [projects overview](/projects).
+If the affected project is not listed there,
+or you are unsure which project is affected,
+send your report to [security@apache.org](mailto:security@apache.org) instead.
+
+Every email you send must meet the following requirements:
+
+* Start the subject line with `[SECURITY]`.
+  This matches an exclusion rule on our spam filter
+  and ensures that your report is not accidentally discarded.
+* Report only one vulnerability per email.
+* Write your report in plain text and do not encrypt it.
+* Explain why you believe the defect is a security issue.
+  If the project publishes a security model
+  on the [projects overview](/projects),
+  describe which of its guarantees the defect breaks.
+* Do not send your report as an image, movie, HTML, Markdown, or PDF attachment
+  when you could as easily describe it in plain text.
+  We will reject such reports and ask you to resubmit them.
+
+By sending your report you agree
+that information from it may be made public
+after triage (for invalid issues) or after the release of the fix,
 unless you explicitly request otherwise.
 
 ## Handling


### PR DESCRIPTION
Restructures the introduction of the "Reporting security issues in ASF code" page so that reporters can more easily find:

- the three requirements for using the security contacts (a security vulnerability, undisclosed, in an ASF project), each with guidance for common mistakes such as forwarding scanner findings about already published CVEs,
- the address to send the report to (per-project address listed on `/projects`, with `security@apache.org` as fallback),
- the formal requirements of report emails, including the `[SECURITY]` subject prefix that matches the spam filter exclusion rule.

The text is reformatted using semantic line breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)