### PR TITLE
Send repository notifications to commits@security.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,8 +1,9 @@
 notifications:
-  commits: private@security.apache.org
-  issues: private@security.apache.org
-  pullrequests: private@security.apache.org
-  discussions: private@security.apache.org
+  commits: commits@security.apache.org
+  issues: commits@security.apache.org
+  jobs: commits@security.apache.org
+  pullrequests: commits@security.apache.org
+  discussions: commits@security.apache.org
 
 staging:
   profile:


### PR DESCRIPTION
Repository event notifications currently go to `private@security.apache.org`, which is meant for confidential traffic. Now that `commits@security.apache.org` exists, point the public repo's event notifications there instead, and add the `jobs` scheme so build notifications land in the same place.

Validated against [apache/infrastructure-asfyaml](https://github.com/apache/infrastructure-asfyaml) (`asfyaml/feature/notifications.py`):

* `commits`, `issues`, `jobs`, `pullrequests` and `discussions` are all in `VALID_NOTIFICATION_SCHEMES`.
* `security-site` resolves to project/hostname `security`, so targets must end in `@security.apache.org`. They do.
* `commits@security.apache.org` matches `RE_VALID_MAILING_LIST` and is an existing list.
* This repository is public, so the `VALID_PRIVATE_TARGETS` restriction does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)