### PR TITLE
Delete head branches after a PR is merged

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,6 +21,8 @@ github:
     - website
   features:
     issues: true
+  pull_requests:
+    del_branch_on_merge: true
   rulesets:
     - name: "Default Branch Protection"
       type: branch


### PR DESCRIPTION
Merged PR branches currently stay around in the repository. This enables GitHub's "automatically delete head branches" setting through `.asf.yaml`.

```yaml
github:
  pull_requests:
    del_branch_on_merge: true
```

Note that this uses `github.pull_requests.del_branch_on_merge` rather than the top-level `github.del_branch_on_merge`. Per [apache/infrastructure-asfyaml](https://github.com/apache/infrastructure-asfyaml) (`asfyaml/feature/github/pull_requests.py`), the top-level key is deprecated, and setting both raises an error.

Only the head branch of a merged PR is affected. Branches covered by the `Default Branch Protection` ruleset (`~DEFAULT_BRANCH`, `release/*`, `rel/*`) already have `restrict_deletion` enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)