### PR TITLE
Add BifroMQ threat model

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -160,6 +160,13 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=Beam)
   - Advisories (experimental):\
     none so far
+- **Apache BifroMQ**
+  - **Security contact:**\
+    [security@apache.org](mailto:security@apache.org?subject=BifroMQ)
+  - Advisories (experimental):\
+    none so far
+  - Security model:
+    - [Apache BifroMQ security model](https://bifromq.apache.org/docs/admin_guide/security/intro/)
 - <img class="project-logo" src="https://www.apache.org/logos/res/bigtop/default.png" alt="" loading="lazy"> **Apache Bigtop**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=Bigtop)

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -454,9 +454,9 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [flink.apache.org](https://flink.apache.org/what-is-flink/security/)
   - Security model:
     - [Apache Flink security model](https://flink.apache.org/what-is-flink/security/)
-- **Apache Fluss (Incubating)**
+- **Apache Fluss**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=Fluss%20%28Incubating%29)
+    [security@apache.org](mailto:security@apache.org?subject=Fluss)
   - Advisories (experimental):\
     [security.apache.org](/projects/fluss/)
 - **Apache Fory**

--- a/content/projects/axis/_index.md
+++ b/content/projects/axis/_index.md
@@ -20,43 +20,6 @@ You can read more about the security policy on:
 This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security pages linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
-## deserialization of untrusted Data ## { #CVE-2026-66713 }
-
-CVE-2026-66713 [\[CVE\]](https://cve.org/CVERecord?id=CVE-2026-66713) [\[CVE json\]](./CVE-2026-66713.cve.json) [\[OSV json\]](./CVE-2026-66713.osv.json)
-
-
-
-_Last updated: 2026-07-28T13:44:22.395Z_
-
-### Affected
-
-* Apache Axis2/Java through 2.0.0
-
-
-### Description
-
-<span style="background-color: rgb(255, 255, 255);">Deserialization</span> <span style="background-color: rgb(255, 255, 255);">of</span> <span style="background-color: rgb(255, 255, 255);">Untrusted</span> <span style="background-color: rgb(255, 255, 255);">Data</span> <span style="background-color: rgb(255, 255, 255);">(CWE-502)</span> <span style="background-color: rgb(255, 255, 255);">in</span> <span style="background-color: rgb(255, 255, 255);">the</span> <span style="background-color: rgb(255, 255, 255);">Tribes-based</span> <span style="background-color: rgb(255, 255, 255);">clustering</span> <span style="background-color: rgb(255, 255, 255);">component</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;in Apache Software Foundation Apache Axis2/Java through 2.0.0 on Apache Tomcat</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;</span><span style="background-color: rgb(255, 255, 255);">(only</span> <span style="background-color: rgb(255, 255, 255);">when</span> <span style="background-color: rgb(255, 255, 255);">Tribes</span> <span style="background-color: rgb(255, 255, 255);">clustering</span> <span style="background-color: rgb(255, 255, 255);">is</span> <span style="background-color: rgb(255, 255, 255);">enabled,</span> <span style="background-color: rgb(255, 255, 255);">which</span> <span style="background-color: rgb(255, 255, 255);">is</span> <span style="background-color: rgb(255, 255, 255);">off</span> <span style="background-color: rgb(255, 255, 255);">by</span> <span style="background-color: rgb(255, 255, 255);">default)</span> <span style="background-color: rgb(255, 255, 255);">allows</span> <span style="background-color: rgb(255, 255, 255);">an</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;unauthenticated remote attacker with network access to the clustering port to</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;execute</span> <span style="background-color: rgb(255, 255, 255);">arbitrary</span> <span style="background-color: rgb(255, 255, 255);">code</span> <span style="background-color: rgb(255, 255, 255);">via</span> <span style="background-color: rgb(255, 255, 255);">a</span> <span style="background-color: rgb(255, 255, 255);">crafted</span> <span style="background-color: rgb(255, 255, 255);">serialized</span> <span style="background-color: rgb(255, 255, 255);">Java</span> <span style="background-color: rgb(255, 255, 255);">object</span> <span style="background-color: rgb(255, 255, 255);">delivered</span> <span style="background-color: rgb(255, 255, 255);">to</span> <span style="background-color: rgb(255, 255, 255);">the</span> <span style="background-color: rgb(255, 255, 255);">cluster</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;</span><span style="background-color: rgb(255, 255, 255);">channel</span> <span style="background-color: rgb(255, 255, 255);">and</span> <span style="background-color: rgb(255, 255, 255);">deserialized</span> <span style="background-color: rgb(255, 255, 255);">in</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;org.apache.axis2.clustering.tribes.Axis2ChannelListener#messageReceived. Users are</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;recommended</span> <span style="background-color: rgb(255, 255, 255);">to</span> <span style="background-color: rgb(255, 255, 255);">upgrade</span> <span style="background-color: rgb(255, 255, 255);">to</span> <span style="background-color: rgb(255, 255, 255);">version</span> <span style="background-color: rgb(255, 255, 255);">2.0.1,</span> <span style="background-color: rgb(255, 255, 255);">which</span> <span style="background-color: rgb(255, 255, 255);">fixes</span> <span style="background-color: rgb(255, 255, 255);">this</span> <span style="background-color: rgb(255, 255, 255);">issue</span> <span style="background-color: rgb(255, 255, 255);">by</span> <span style="background-color: rgb(255, 255, 255);">removing</span> <span style="background-color: rgb(255, 255, 255);">the</span>
-<br><span style="background-color: rgb(255, 255, 255);"> &nbsp;clustering feature entirely.</span><br>
-<br>
-
-<br>
-
-### References
-* https://github.com/apache/axis-axis2-java-core/commit/e6f53b230bddcb40577c84ff290ba51e7265fa15
-* https://lists.apache.org/thread/fgggbv3sjjqw7p6q0j88gspt9b2rb728
-
-
-### Credits
-* liuhuajin of Huawei (finder)
-
-
 ## Apache Axis 1.x (EOL) may allow SSRF when untrusted input is passed to the service admin HTTP API ## { #CVE-2023-51441 }
 
 CVE-2023-51441 [\[CVE\]](https://cve.org/CVERecord?id=CVE-2023-51441) [\[CVE json\]](./CVE-2023-51441.cve.json) [\[OSV json\]](./CVE-2023-51441.osv.json)

--- a/content/projects/fluss/_index.md
+++ b/content/projects/fluss/_index.md
@@ -1,12 +1,12 @@
 ---
-title: Apache Fluss (Incubating) security advisories
-description: Security information for Apache Fluss (Incubating)
+title: Apache Fluss security advisories
+description: Security information for Apache Fluss
 layout: single
 ---
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache Fluss (Incubating)? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Fluss%20%28Incubating%29).
+Do you want disclose a potential security issue for Apache Fluss? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Fluss).
 
 # Advisories
 

--- a/content/projects/thrift/_index.md
+++ b/content/projects/thrift/_index.md
@@ -387,7 +387,7 @@ CVE-2026-43870 [\[CVE\]](https://cve.org/CVERecord?id=CVE-2026-43870) [\[CVE jso
 
 
 
-_Last updated: 2026-05-05T07:45:34.804Z_
+_Last updated: 2026-08-01T15:14:33.689Z_
 
 ### Affected
 
@@ -408,7 +408,7 @@ CVE-2026-43869 [\[CVE\]](https://cve.org/CVERecord?id=CVE-2026-43869) [\[CVE jso
 
 
 
-_Last updated: 2026-05-05T07:25:46.713Z_
+_Last updated: 2026-08-01T15:15:50.815Z_
 
 ### Affected
 
@@ -476,7 +476,7 @@ CVE-2026-41608 [\[CVE\]](https://cve.org/CVERecord?id=CVE-2026-41608) [\[CVE jso
 
 
 
-_Last updated: 2026-07-27T10:53:37.845Z_
+_Last updated: 2026-08-01T15:15:08.921Z_
 
 ### Affected
 

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -191,6 +191,14 @@
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/beam/default.png"
   },
+  "bifromq": {
+    "name": "Apache BifroMQ",
+    "security_model_link": "https://bifromq.apache.org/docs/admin_guide/security/intro/",
+    "security_model_source": "https://raw.githubusercontent.com/apache/bifromq-sites/master/docs/admin_guide/security/intro.md",
+    "advisory_link": null,
+    "contact": "security@apache.org",
+    "logo_link": null
+  },
   "bigtop": {
     "name": "Apache Bigtop",
     "security_model_link": null,


### PR DESCRIPTION
Adds a reference to the Apache BifroMQ security model to `security.apache.org`, following the same pattern as #75 (Calcite): a `security_model_link` / `security_model_source` pair in `scripts/project-coordinates.json`, plus the regenerated pages. BifroMQ was not listed before, so this also creates its entry in the projects overview.

Two commits:

1. **Add BifroMQ threat model**: `scripts/project-coordinates.json` and the corresponding entry in the projects overview.
2. **Regenerate project pages**: unrelated output of the same regeneration run, kept separate for review.

CVE-2026-66713 has been marked as `DRAFT` again, in preparation for an update, which is why it is no longer present on the website.