### PR TITLE
Add Syncope threat model

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1376,6 +1376,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=Syncope)
   - Advisories:\
     [syncope.apache.org](https://syncope.apache.org/security)
+  - Security model:
+    - [Apache Syncope security model](https://syncope.apache.org/docs/reference-guide.html#rest-authorization-summary)
 - **Apache SystemDS**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=SystemDS)

--- a/content/projects/syncope/_index.md
+++ b/content/projects/syncope/_index.md
@@ -8,9 +8,14 @@ layout: single
 
 Do you want disclose a potential security issue for Apache Syncope? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Syncope).
 
+You can read more about the security policy on:
+
+- [Apache Syncope security model](https://syncope.apache.org/docs/reference-guide.html#rest-authorization-summary)
+
+
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## RCE via Groovy Sandbox bypass ## { #CVE-2026-63071 }

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -1722,8 +1722,8 @@
   },
   "syncope": {
     "name": "Apache Syncope",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://syncope.apache.org/docs/reference-guide.html#rest-authorization-summary",
+    "security_model_source": "https://raw.githubusercontent.com/apache/syncope/master/src/main/asciidoc/reference-guide/usage/core.adoc",
     "advisory_link": "https://syncope.apache.org/security",
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/syncope/default.png"


### PR DESCRIPTION
Apache Syncope has no dedicated security page, but the reference guide contains a [REST Authorization Summary](https://syncope.apache.org/docs/reference-guide.html#rest-authorization-summary) that partitions its RESTful services by the authentication and authorization each one requires:

1. anonymous endpoints (self-registration, password reset),
2. endpoints disclosing deployment information, gated by the shared `security.anonymousKey`,
3. self-service endpoints requiring user authentication and no entitlements,
4. administrative endpoints requiring entitlements handed to users through roles.

That is the closest thing the project currently documents to a threat model, so this links it as a stopgap until the PMC publishes something better.

`security_model_source` points at `src/main/asciidoc/reference-guide/usage/core.adoc`, the AsciiDoc file that anchor is generated from, matching how Artemis, Camel and Cassandra are recorded.

Stacked on #82, since both regenerate `content/projects/_index.md`. GitHub will retarget this to `main` once that one merges.