### PR TITLE
Add security coordinates for Apache Sourcelume

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1295,6 +1295,11 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [solr.apache.org](https://solr.apache.org/security.html#recent-cve-reports-for-apache-solr)
   - Security model:
     - [Apache Solr security model](https://github.com/apache/solr/blob/main/THREAT_MODEL.md)
+- **Apache Sourcelume**
+  - **Security contact:**\
+    [security@sourcelume.apache.org](mailto:security@sourcelume.apache.org?subject=Sourcelume)
+  - Advisories (experimental):\
+    none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/spamassassin/default.png" alt="" loading="lazy"> **Apache SpamAssassin**
   - **Security contact:**\
     [security@spamassassin.apache.org](mailto:security@spamassassin.apache.org?subject=SpamAssassin)

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -1624,6 +1624,14 @@
     "dependency_advisory_triage": "https://solr.apache.org/solr.vex.json",
     "logo_link": "https://www.apache.org/logos/res/solr/default.png"
   },
+  "sourcelume": {
+    "name": "Apache Sourcelume",
+    "security_model_link": null,
+    "security_model_source": null,
+    "advisory_link": null,
+    "contact": "security@sourcelume.apache.org",
+    "logo_link": null
+  },
   "spamassassin": {
     "name": "Apache SpamAssassin",
     "security_model_link": "https://cwiki.apache.org/confluence/display/SPAMASSASSIN/SecurityPolicy",


### PR DESCRIPTION
Stacked on #84.

The mailing list security@sourcelume.apache.org has been created, so this adds security coordinates for Apache Sourcelume (new TLP, established 2026-08, "AI training-data provenance") and regenerates the projects overview.

The project has no website, logo, security model or advisories yet, so every optional field is null and only the dedicated security contact carries information.
