### PR TITLE
Add security coordinates for Asyncband and Maka podlings

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -133,6 +133,11 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=AsterixDB)
   - Advisories (experimental):\
     [security.apache.org](/projects/asterixdb/)
+- **Apache Asyncband (Incubating)**
+  - **Security contact:**\
+    [security@apache.org](mailto:security@apache.org?subject=Asyncband%20%28Incubating%29)
+  - Advisories (experimental):\
+    none so far
 - <img class="project-logo" src="https://www.apache.org/logos/res/atlas/default.png" alt="" loading="lazy"> **Apache Atlas**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=Atlas)
@@ -881,6 +886,13 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=Mahout)
   - Advisories (experimental):\
     none so far
+- **Apache Maka (Incubating)**
+  - **Security contact:**\
+    [security@apache.org](mailto:security@apache.org?subject=Maka%20%28Incubating%29)
+  - Advisories (experimental):\
+    none so far
+  - Security model:
+    - [Apache Maka (Incubating) security model](https://github.com/apache/maka/blob/main/SECURITY.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/manifoldcf/default.png" alt="" loading="lazy"> **Apache ManifoldCF**
   - **Security contact:**\
     [security@apache.org](mailto:security@apache.org?subject=ManifoldCF)

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -140,6 +140,14 @@
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/asterixdb/default.png"
   },
+  "asyncband": {
+    "name": "Apache Asyncband (Incubating)",
+    "security_model_link": null,
+    "security_model_source": null,
+    "advisory_link": null,
+    "contact": "security@apache.org",
+    "logo_link": null
+  },
   "atlas": {
     "name": "Apache Atlas",
     "security_model_link": null,
@@ -1095,6 +1103,15 @@
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/mahout/default.png"
+  },
+  "maka": {
+    "name": "Apache Maka (Incubating)",
+    "security_model_link": "https://github.com/apache/maka/blob/main/SECURITY.md",
+    "security_model_source": "https://raw.githubusercontent.com/apache/maka/main/SECURITY.md",
+    "advisory_link": null,
+    "contact": "security@apache.org",
+    "contributing": "https://github.com/apache/maka/blob/main/CONTRIBUTING.md",
+    "logo_link": null
   },
   "manifoldcf": {
     "name": "Apache ManifoldCF",


### PR DESCRIPTION
Stacked on #85.

Adds security coordinates for the two podlings the generator warned about, both incubating since 2026-08:

- **Apache Asyncband (Incubating)** — synchronization primitives for async Rust. No security page, logo or dedicated list yet, so everything except the default contact is null.
- **Apache Maka (Incubating)** — local-first AI agent runtime. Links its repository [SECURITY.md](https://github.com/apache/maka/blob/main/SECURITY.md) as security model (with the raw URL as source) and its CONTRIBUTING.md as contributing guide.

Neither podling has a dedicated `security@` list on lists.apache.org, so both use security@apache.org.

Note for the security team: Maka's SECURITY.md still directs vulnerability reports to `security@maka.app`, a pre-incubation address — the podling should be asked to switch its policy to the ASF reporting process.
