### PR TITLE
Add security model coordinates for Apache OpenNLP

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -994,6 +994,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=OpenNLP)
   - Advisories (experimental):\
     [security.apache.org](/projects/opennlp/)
+  - Security model:
+    - [Apache OpenNLP security model](https://github.com/apache/opennlp/security/policy)
 - <img class="project-logo" src="https://www.apache.org/logos/res/openoffice/default.png" alt="" loading="lazy"> **Apache OpenOffice**
   - **Security contact:**\
     [security@openoffice.apache.org](mailto:security@openoffice.apache.org?subject=OpenOffice)

--- a/content/projects/opennlp/_index.md
+++ b/content/projects/opennlp/_index.md
@@ -8,9 +8,14 @@ layout: single
 
 Do you want disclose a potential security issue for Apache OpenNLP? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=OpenNLP).
 
+You can read more about the security policy on:
+
+- [Apache OpenNLP security model](https://github.com/apache/opennlp/security/policy)
+
+
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## Arbitrary Class Instantiation in GeneratorFactory via Feature Descriptor XML ## { #CVE-2026-63317 }

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -1228,8 +1228,8 @@
   },
   "opennlp": {
     "name": "Apache OpenNLP",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/opennlp/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/opennlp/main/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/opennlp/default.png"


### PR DESCRIPTION
Apache OpenNLP now has a threat model: the "Security Policy and Security Model" document in [`SECURITY.md`](https://github.com/apache/opennlp/blob/main/SECURITY.md) of the `apache/opennlp` repository. The project's [website security page](https://opennlp.apache.org/security.html) points to that document as the authoritative version.

Since the threat model lives in `SECURITY.md` on the default branch, the `security_model_link` uses the GitHub `security/policy` URL, following the existing convention (e.g. Fineract, Axis2).

Stacked on #88 to keep the CVE-data regeneration reviewable separately; only the last two commits belong to this PR.