### PR TITLE
Add security model coordinates for Apache Wicket

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1586,6 +1586,8 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     [security@apache.org](mailto:security@apache.org?subject=Wicket)
   - Advisories (experimental):\
     [security.apache.org](/projects/wicket/)
+  - Security model:
+    - [Apache Wicket security model](https://github.com/apache/wicket/security/policy)
 
 </section>
 <section class="project-tab-panel" role="tabpanel" data-letter="X">

--- a/content/projects/wicket/_index.md
+++ b/content/projects/wicket/_index.md
@@ -8,9 +8,14 @@ layout: single
 
 Do you want disclose a potential security issue for Apache Wicket? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=Wicket).
 
+You can read more about the security policy on:
+
+- [Apache Wicket security model](https://github.com/apache/wicket/security/policy)
+
+
 # Advisories
 
-This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
+This section is experimental: it provides advisories since 2023 and may lag behind the official CVE publications. It may also lack details found on the project security page linked above. If you have any feedback on how you would like this data to be provided, you are welcome to reach out on our public [mailinglist](/mailinglist) or privately on [security@apache.org](mailto:security@apache.org)
 {.bg-warning}
 
 ## leaked and missing CSP headers ## { #CVE-2026-66391 }

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -1988,8 +1988,8 @@
   },
   "wicket": {
     "name": "Apache Wicket",
-    "security_model_link": null,
-    "security_model_source": null,
+    "security_model_link": "https://github.com/apache/wicket/security/policy",
+    "security_model_source": "https://raw.githubusercontent.com/apache/wicket/master/SECURITY.md",
     "advisory_link": null,
     "contact": "security@apache.org",
     "logo_link": "https://www.apache.org/logos/res/wicket/default.png"


### PR DESCRIPTION
Apache Wicket documents its security model in [`SECURITY.md`](https://github.com/apache/wicket/blob/master/SECURITY.md) in the root of the `apache/wicket` repository. Alongside the reporting process, supported release lines and scope, it has a "Security Model" section documenting which inputs the framework treats as trusted — the container-reported host, port and scheme; `X-Forwarded-*` headers; serialized page and session data; markup files and message bundles — and what the `ResourceIsolationRequestCycleListener` and `CryptoMapper` boundaries do and do not claim.

Since the model lives in `SECURITY.md` on the default branch (`master`), `security_model_link` uses the GitHub `security/policy` URL and `security_model_source` the raw URL, following the existing convention (e.g. Fineract, Axis2).

Also regenerates the two affected pages: the Wicket card on the projects overview, and `/projects/wicket/`, which already exists because advisories are held for Wicket.

Both URLs were verified to resolve (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
