### PR TITLE
Use the new HBase and Phoenix security lists as contacts

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -607,7 +607,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     - [Apache Hamilton (Incubating) security model](https://github.com/apache/hamilton/blob/main/SECURITY.md)
 - <img class="project-logo" src="https://www.apache.org/logos/res/hbase/default.png" alt="" loading="lazy"> **Apache HBase**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=HBase)
+    [security@hbase.apache.org](mailto:security@hbase.apache.org?subject=HBase)
   - Advisories (experimental):\
     [security.apache.org](/projects/hbase/)
   - Security model:
@@ -1088,7 +1088,7 @@ Use the tabs below to jump to projects by their initial. Every project lists a s
     - [Apache Pekko security model](https://pekko.apache.org/docs/pekko/current/security/index.html)
 - <img class="project-logo" src="https://www.apache.org/logos/res/phoenix/default.png" alt="" loading="lazy"> **Apache Phoenix**
   - **Security contact:**\
-    [security@apache.org](mailto:security@apache.org?subject=Phoenix)
+    [security@phoenix.apache.org](mailto:security@phoenix.apache.org?subject=Phoenix)
   - Advisories (experimental):\
     none so far
   - Security model:

--- a/content/projects/hbase/_index.md
+++ b/content/projects/hbase/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Reporting
 
-Do you want disclose a potential security issue for Apache HBase? Send your report to the [Apache Security Team](mailto:security@apache.org?subject=HBase).
+Do you want disclose a potential security issue for Apache HBase? Send your report to the [Apache HBase Security Team](mailto:security@hbase.apache.org?subject=HBase).
 
 You can read more about the security policy on:
 

--- a/scripts/project-coordinates.json
+++ b/scripts/project-coordinates.json
@@ -777,7 +777,7 @@
     "security_model_link": "https://hbase.apache.org/security-model/",
     "security_model_source": null,
     "advisory_link": null,
-    "contact": "security@apache.org",
+    "contact": "security@hbase.apache.org",
     "contributing": "https://hbase.apache.org/#community",
     "logo_link": "https://www.apache.org/logos/res/hbase/default.png"
   },
@@ -1360,7 +1360,7 @@
     "security_model_link": "https://phoenix.apache.org/security-model/",
     "security_model_source": "https://raw.githubusercontent.com/apache/phoenix-site/refs/heads/asf-site/app/pages/_landing/security-model/content.md",
     "advisory_link": null,
-    "contact": "security@apache.org",
+    "contact": "security@phoenix.apache.org",
     "logo_link": "https://www.apache.org/logos/res/phoenix/default.png"
   },
   "pig": {


### PR DESCRIPTION
The HBase and Phoenix PMCs have created dedicated security mailing lists, security@hbase.apache.org and security@phoenix.apache.org. This points the `contact` field of both projects in `scripts/project-coordinates.json` at those lists and regenerates the projects overview and the HBase project page accordingly (Phoenix has no per-project page yet, as it has no published advisories).

Follows the CVE regeneration in #94.
